### PR TITLE
Update Liveblocks dependencies from 3.11.1 to 3.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "mysteryvs",
       "version": "0.1.0",
       "dependencies": {
-        "@liveblocks/client": "^3.11.1",
-        "@liveblocks/node": "^3.11.1",
-        "@liveblocks/react": "^3.11.1",
+        "@liveblocks/client": "^3.15.0",
+        "@liveblocks/node": "^3.15.0",
+        "@liveblocks/react": "^3.15.0",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
@@ -1064,43 +1064,43 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-3.11.1.tgz",
-      "integrity": "sha512-LsVNUJeZDNfWfCmGWAIn0ulpCWfL0KSciVA2jfTxFrMueMBEZR+rMrg8zRNG8taG0SNO+hm735GnNdnHUn9hDA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-3.15.0.tgz",
+      "integrity": "sha512-Nz4PRtc8mlTzlTudm/XvuO2148qOesslJnRQXvPcO7RKvkNdu4KVsyAfcEBHMYu/0iOIulKX61TV5kzVO0vTYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "3.11.1"
+        "@liveblocks/core": "3.15.0"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-3.11.1.tgz",
-      "integrity": "sha512-YAbOjoLZsN0G8e3EjcDeXsC771dFzymiuCwXV60B2kNN+rMvq6l2xZDpRvoNiDCqHg/4CThoWEVAl8OqvQ6j9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-3.15.0.tgz",
+      "integrity": "sha512-nc8/NsDsIkFUE4EcFf2/gCZNAbRTmX8Aks0o3AAM0oDx4hW9EgkQo8m4d+ReQNQ5W6fdep+GV6emwc2/l8jMLQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@types/json-schema": "^7"
       }
     },
     "node_modules/@liveblocks/node": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-3.11.1.tgz",
-      "integrity": "sha512-5JANLxdlSh1IPM3uF1f0vcQVCqcM9rN1p9hknZl9y7IEaHg+p2wh97KlH3nrBEDw4gwbuulx6V+oU/7IdG4LyA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-3.15.0.tgz",
+      "integrity": "sha512-SJaVUqaWn/F8fOYMfapx2B14/vdCTRke/yYWIUWISRnlT/nje7oOnO28Z9I8thtdFh4LMgbR9zl9OEa0vLNjCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "3.11.1",
+        "@liveblocks/core": "3.15.0",
         "@stablelib/base64": "^1.0.1",
         "fast-sha256": "^1.3.0",
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-3.11.1.tgz",
-      "integrity": "sha512-M48L8LaxA3vVPsFHOhcwVPkyGH/FuoYhl88KIvo9D734KlGbjpK8h+L0bjkAc6/+jmh1PHdn1m0zBq4rRNTTeA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-3.15.0.tgz",
+      "integrity": "sha512-RTdEon5HMVS3SRV3KpwtHIbnWWJL2VQ1ljAyScueXc91mH0oKHXoGxTmheNELP9AnwSONPMcNYsF2MFJuf/1pw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "3.11.1",
-        "@liveblocks/core": "3.11.1"
+        "@liveblocks/client": "3.15.0",
+        "@liveblocks/core": "3.15.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "verify": "npm run type-check && npm run lint && npm run format:check"
   },
   "dependencies": {
-    "@liveblocks/client": "^3.11.1",
-    "@liveblocks/node": "^3.11.1",
-    "@liveblocks/react": "^3.11.1",
+    "@liveblocks/client": "^3.15.0",
+    "@liveblocks/node": "^3.15.0",
+    "@liveblocks/react": "^3.15.0",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
No breaking changes required — largeMessageStrategy (the only breaking change in this range) is not used in this codebase.

https://claude.ai/code/session_012n1avEcz33kwpPtCdQW7jx