### PR TITLE
Show tournament name from Liveblocks storage in navbar

### DIFF
--- a/app/TopNav.tsx
+++ b/app/TopNav.tsx
@@ -2,8 +2,9 @@ import Link from "next/link";
 import { Settings } from "lucide-react";
 import { getUsername } from "@/app/login/getUsername";
 import { AvatarMenu } from "@/app/AvatarMenu";
+import { ReactNode } from "react";
 
-export async function TopNav() {
+export async function TopNav({ title }: { title?: ReactNode }) {
   const username = await getUsername();
 
   return (
@@ -12,7 +13,7 @@ export async function TopNav() {
         href="/"
         className="font-semibold text-lg hover:text-muted-foreground"
       >
-        PTI Mysteeri 2025
+        {title ?? "Mystery Versus"}
       </Link>
       <div className="flex items-center gap-3">
         <Link

--- a/app/TournamentName.tsx
+++ b/app/TournamentName.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useName } from "@/app/mysteryhooks";
+
+export function TournamentName() {
+  const name = useName();
+  return <>{name}</>;
+}

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -7,7 +7,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { addParticipant, removeParticipant, setName } from "@/app/admin/actions";
+import {
+  addParticipant,
+  removeParticipant,
+  setName,
+} from "@/app/admin/actions";
 import { Button } from "@/components/ui/button";
 import Form from "next/form";
 import { Label } from "@/components/ui/label";

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -7,7 +7,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { addParticipant, removeParticipant } from "@/app/admin/actions";
+import { addParticipant, removeParticipant, setName } from "@/app/admin/actions";
 import { Button } from "@/components/ui/button";
 import Form from "next/form";
 import { Label } from "@/components/ui/label";
@@ -15,12 +15,20 @@ import { Input } from "@/components/ui/input";
 
 export function AdminPage({
   participants,
+  name,
 }: {
   participants: readonly string[];
+  name: string;
 }) {
   return (
     <div>
       <h1>Pelaajien hallinta</h1>
+      <h2>Turnauksen nimi</h2>
+      <Form action={setName} className="space-y-8">
+        <Label htmlFor="name">Nimi</Label>
+        <Input defaultValue={name} name="name" />
+        <Button>Tallenna</Button>
+      </Form>
       <h2>Osallistujat</h2>
       <Table>
         <TableHeader>

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -16,6 +16,64 @@ import { Button } from "@/components/ui/button";
 import Form from "next/form";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { useRef, useState, useTransition } from "react";
+
+function InlineNameEdit({ name }: { name: string }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(name);
+  const [isPending, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function save() {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === name) {
+      setValue(name);
+      setEditing(false);
+      return;
+    }
+    startTransition(async () => {
+      await setName(trimmed);
+      setEditing(false);
+    });
+  }
+
+  function cancel() {
+    setValue(name);
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <Input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={save}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            save();
+          } else if (e.key === "Escape") {
+            cancel();
+          }
+        }}
+        disabled={isPending}
+        autoFocus
+        className="max-w-sm"
+      />
+    );
+  }
+
+  return (
+    <span
+      className="cursor-pointer rounded px-1 hover:bg-accent"
+      onClick={() => setEditing(true)}
+      title="Click to edit"
+    >
+      {value}
+    </span>
+  );
+}
 
 export function AdminPage({
   participants,
@@ -28,11 +86,7 @@ export function AdminPage({
     <div>
       <h1>Pelaajien hallinta</h1>
       <h2>Turnauksen nimi</h2>
-      <Form action={setName} className="space-y-8">
-        <Label htmlFor="name">Nimi</Label>
-        <Input defaultValue={name} name="name" />
-        <Button>Tallenna</Button>
-      </Form>
+      <InlineNameEdit name={name} />
       <h2>Osallistujat</h2>
       <Table>
         <TableHeader>

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -16,64 +16,6 @@ import { Button } from "@/components/ui/button";
 import Form from "next/form";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { useRef, useState, useTransition } from "react";
-
-function InlineNameEdit({ name }: { name: string }) {
-  const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(name);
-  const [isPending, startTransition] = useTransition();
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  function save() {
-    const trimmed = value.trim();
-    if (!trimmed || trimmed === name) {
-      setValue(name);
-      setEditing(false);
-      return;
-    }
-    startTransition(async () => {
-      await setName(trimmed);
-      setEditing(false);
-    });
-  }
-
-  function cancel() {
-    setValue(name);
-    setEditing(false);
-  }
-
-  if (editing) {
-    return (
-      <Input
-        ref={inputRef}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onBlur={save}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            save();
-          } else if (e.key === "Escape") {
-            cancel();
-          }
-        }}
-        disabled={isPending}
-        autoFocus
-        className="max-w-sm"
-      />
-    );
-  }
-
-  return (
-    <span
-      className="cursor-pointer rounded px-1 hover:bg-accent"
-      onClick={() => setEditing(true)}
-      title="Click to edit"
-    >
-      {value}
-    </span>
-  );
-}
 
 export function AdminPage({
   participants,
@@ -86,7 +28,11 @@ export function AdminPage({
     <div>
       <h1>Pelaajien hallinta</h1>
       <h2>Turnauksen nimi</h2>
-      <InlineNameEdit name={name} />
+      <Form action={setName} className="space-y-8">
+        <Label htmlFor="name">Nimi</Label>
+        <Input defaultValue={name} name="name" />
+        <Button>Tallenna</Button>
+      </Form>
       <h2>Osallistujat</h2>
       <Table>
         <TableHeader>

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -26,7 +26,7 @@ export function AdminPage({
 }) {
   return (
     <div>
-      <h1>Pelaajien hallinta</h1>
+      <h1 className="text-2xl font-bold mb-6">Hallintapaneeli</h1>
       <h2>Turnauksen nimi</h2>
       <Form action={setName} className="space-y-8">
         <Label htmlFor="name">Nimi</Label>

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -29,7 +29,6 @@ export function AdminPage({
       <h1 className="text-2xl font-bold mb-6">Hallintapaneeli</h1>
       <h2>Turnauksen nimi</h2>
       <Form action={setName} className="space-y-8">
-        <Label htmlFor="name">Nimi</Label>
         <Input defaultValue={name} name="name" />
         <Button>Tallenna</Button>
       </Form>

--- a/app/admin/AdminPage.tsx
+++ b/app/admin/AdminPage.tsx
@@ -27,8 +27,8 @@ export function AdminPage({
   return (
     <div>
       <h1 className="text-2xl font-bold mb-6">Hallintapaneeli</h1>
-      <h2>Turnauksen nimi</h2>
       <Form action={setName} className="space-y-8">
+        <Label htmlFor="name">Turnauksen nimi</Label>
         <Input defaultValue={name} name="name" />
         <Button>Tallenna</Button>
       </Form>

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -4,6 +4,17 @@ import { revalidatePath } from "next/cache";
 
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 
+export async function setName(data: FormData) {
+  const name = data.get("name") as string;
+  if (!name) {
+    throw new Error("Name is required");
+  }
+  await liveblocks.mutateStorage(room, async ({ root }) => {
+    root.set("name", name);
+  });
+  revalidatePath("/admin");
+}
+
 export async function removeParticipant(id: string) {
   await liveblocks.mutateStorage(room, async ({ root }) => {
     const participants = root.get("participants");

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -4,8 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 
-export async function setName(data: FormData) {
-  const name = data.get("name") as string;
+export async function setName(name: string) {
   if (!name) {
     throw new Error("Name is required");
   }

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from "next/cache";
 
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 
-export async function setName(name: string) {
+export async function setName(data: FormData) {
+  const name = data.get("name") as string;
   if (!name) {
     throw new Error("Name is required");
   }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,13 +1,18 @@
 import { getParticipants } from "@/app/login/getParticipants";
 import { AdminPage } from "@/app/admin/AdminPage";
 import { TopNav } from "@/app/TopNav";
+import { liveblocks } from "@/app/liveblocks/liveblocks";
+import { room } from "@/app/constants";
 
 export default async function AdminPageServer() {
-  const participants = await getParticipants();
+  const [participants, storage] = await Promise.all([
+    getParticipants(),
+    liveblocks.getStorageDocument(room, "json"),
+  ]);
   return (
     <>
       <TopNav />
-      <AdminPage participants={participants} />
+      <AdminPage participants={participants} name={storage.name} />
     </>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,7 +1,13 @@
 import { getParticipants } from "@/app/login/getParticipants";
 import { AdminPage } from "@/app/admin/AdminPage";
+import { TopNav } from "@/app/TopNav";
 
 export default async function AdminPageServer() {
   const participants = await getParticipants();
-  return <AdminPage participants={participants} />;
+  return (
+    <>
+      <TopNav />
+      <AdminPage participants={participants} />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
-import { TopNav } from "@/app/TopNav";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -29,7 +28,6 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <TopNav />
         {children}
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 
 import { LoginClientPage } from "@/app/login/LoginClientPage";
 import { Room } from "@/app/Room";
+import { TopNav } from "@/app/TopNav";
+import { TournamentName } from "@/app/TournamentName";
 
 export default async function Login() {
   const username = await getUsername();
@@ -12,6 +14,7 @@ export default async function Login() {
 
   return (
     <Room>
+      <TopNav title={<TournamentName />} />
       <LoginClientPage />
     </Room>
   );

--- a/app/mysteryhooks.ts
+++ b/app/mysteryhooks.ts
@@ -19,3 +19,7 @@ export function useParticipantTime(id: string) {
 export function useHost() {
   return useStorage((root) => root.host);
 }
+
+export function useName() {
+  return useStorage((root) => root.name);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,8 @@ import { Room } from "@/app/Room";
 import { getUsername } from "@/app/login/getUsername";
 import { redirect } from "next/navigation";
 import { MysteryRoundPage } from "@/app/MysteryRoundPage";
+import { TopNav } from "@/app/TopNav";
+import { TournamentName } from "@/app/TournamentName";
 
 export default async function Home() {
   const username = await getUsername();
@@ -10,6 +12,7 @@ export default async function Home() {
   }
   return (
     <Room>
+      <TopNav title={<TournamentName />} />
       <MysteryRoundPage />
     </Room>
   );


### PR DESCRIPTION
Replaces the hardcoded "PTI Mysteeri 2025" string with the `name` field
read live from Liveblocks storage. TopNav is moved from layout into each
page so it can render inside the Room (Liveblocks) context where needed.
Admin page uses TopNav without a Room, falling back to "Mystery Versus".

https://claude.ai/code/session_013Ev8RJwdrCRMGrMktgyPAR