### PR TITLE
Use player cards for organizer selection instead of table

### DIFF
--- a/app/MysteryRoundPage.tsx
+++ b/app/MysteryRoundPage.tsx
@@ -14,8 +14,8 @@ export function MysteryRoundPage() {
   const startTime = useStartTime();
   const description = useDescription();
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center p-8 pb-20 gap-16 sm:p-20 font-(family-name:--font-geist-sans)">
-      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center p-4 pb-20 gap-16 sm:p-20 font-(family-name:--font-geist-sans)">
+      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start w-full max-w-lg">
         {description && (
           <div className="prose prose-sm dark:prose-invert">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>

--- a/app/Participants.tsx
+++ b/app/Participants.tsx
@@ -21,7 +21,7 @@ export function Participants() {
 
   if (!host && !startTime) {
     return (
-      <div className="flex flex-wrap gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
         {participants.map((participant) => (
           <ParticipantCard key={participant.id} participant={participant} />
         ))}
@@ -68,8 +68,8 @@ function ParticipantCard({ participant }: { participant: Participant }) {
   );
 
   return (
-    <button onClick={setHost}>
-      <Card className="w-40 h-24 cursor-pointer hover:bg-accent transition-colors">
+    <button onClick={setHost} className="w-full">
+      <Card className="w-full h-20 cursor-pointer hover:bg-accent transition-colors">
         <CardContent className="flex items-center justify-center h-full pt-6">
           <span className="text-xl font-semibold">{participant.name}</span>
         </CardContent>


### PR DESCRIPTION
When no host is selected and the round hasn't started, participants
are shown as a grid of clickable cards rather than in a table.
Clicking a card sets that player as the round organizer.
The table view is preserved for the in-round phase.

https://claude.ai/code/session_01HNK41wFAaBHScig2Cej5R9