### PR TITLE
Add Neon database persistence for round results

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Liveblocks secret key – get from https://liveblocks.io/dashboard
+LIVEBLOCKS_SECRET=your_liveblocks_secret_here
+
+# Neon Postgres connection string – get from https://console.neon.tech
+DATABASE_URL=postgresql://user:password@host/dbname

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,12 @@ npm run verify       # Run all validations (type-check + lint + format check)
 
 ### Environment Variables
 
-- `LIVEBLOCKS_SECRET`: Required for real-time collaboration. Set in `.env` file.
-- The application validates environment variables at build time in `next.config.ts` and will exit if missing.
+Copy `.env.example` to `.env` and fill in the values:
+
+- `LIVEBLOCKS_SECRET`: Required for real-time collaboration. Get from [liveblocks.io/dashboard](https://liveblocks.io/dashboard).
+- `DATABASE_URL`: Required for database persistence. Neon Postgres connection string. Get from [console.neon.tech](https://console.neon.tech).
+
+The application validates both variables at build time in `next.config.ts` and will exit if either is missing.
 
 ## Architecture
 

--- a/app/MysteryRoundPage.tsx
+++ b/app/MysteryRoundPage.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useMutation } from "@liveblocks/react/suspense";
 import { Timer } from "@/components/ui/timer";
 import { Participants } from "@/app/Participants";
@@ -32,6 +32,10 @@ export function MysteryRoundPage() {
   const name = useName();
   const participantTimes = useParticipantTimes();
   const savedRoundRef = useRef<number | null>(null);
+  const payloadRef = useRef({ name, host, participantTimes });
+  useLayoutEffect(() => {
+    payloadRef.current = { name, host, participantTimes };
+  });
 
   useEffect(() => {
     if (!completedTime || savedRoundRef.current === completedTime) return;
@@ -40,13 +44,11 @@ export function MysteryRoundPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        name,
-        host,
+        ...payloadRef.current,
         completedAt: completedTime,
-        participantTimes,
       }),
     }).catch(console.error);
-  }, [completedTime, host, name, participantTimes]);
+  }, [completedTime]);
 
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center p-4 pb-20 gap-16 sm:p-20 font-(family-name:--font-geist-sans)">

--- a/app/MysteryRoundPage.tsx
+++ b/app/MysteryRoundPage.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useEffect, useLayoutEffect, useRef } from "react";
 import { useMutation } from "@liveblocks/react/suspense";
 import { Timer } from "@/components/ui/timer";
 import { Participants } from "@/app/Participants";
@@ -9,8 +8,6 @@ import {
   useDescription,
   useHost,
   useIsRunning,
-  useName,
-  useParticipantTimes,
   useRoundType,
   useStartTime,
 } from "@/app/mysteryhooks";
@@ -29,26 +26,6 @@ export function MysteryRoundPage() {
   const roundType = useRoundType();
   const setRoundType = useSetRoundType();
   const isScoreMode = roundType === "score";
-  const name = useName();
-  const participantTimes = useParticipantTimes();
-  const savedRoundRef = useRef<number | null>(null);
-  const payloadRef = useRef({ name, host, participantTimes });
-  useLayoutEffect(() => {
-    payloadRef.current = { name, host, participantTimes };
-  });
-
-  useEffect(() => {
-    if (!completedTime || savedRoundRef.current === completedTime) return;
-    savedRoundRef.current = completedTime;
-    fetch("/api/rounds", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        ...payloadRef.current,
-        completedAt: completedTime,
-      }),
-    }).catch(console.error);
-  }, [completedTime]);
 
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center p-4 pb-20 gap-16 sm:p-20 font-(family-name:--font-geist-sans)">

--- a/app/MysteryRoundPage.tsx
+++ b/app/MysteryRoundPage.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect, useRef } from "react";
 import { useMutation } from "@liveblocks/react/suspense";
 import { Timer } from "@/components/ui/timer";
 import { Participants } from "@/app/Participants";
@@ -8,6 +9,8 @@ import {
   useDescription,
   useHost,
   useIsRunning,
+  useName,
+  useParticipantTimes,
   useRoundType,
   useStartTime,
 } from "@/app/mysteryhooks";
@@ -26,6 +29,24 @@ export function MysteryRoundPage() {
   const roundType = useRoundType();
   const setRoundType = useSetRoundType();
   const isScoreMode = roundType === "score";
+  const name = useName();
+  const participantTimes = useParticipantTimes();
+  const savedRoundRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!completedTime || savedRoundRef.current === completedTime) return;
+    savedRoundRef.current = completedTime;
+    fetch("/api/rounds", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        host,
+        completedAt: completedTime,
+        participantTimes,
+      }),
+    }).catch(console.error);
+  }, [completedTime, host, name, participantTimes]);
 
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center p-4 pb-20 gap-16 sm:p-20 font-(family-name:--font-geist-sans)">

--- a/app/api/rounds/route.ts
+++ b/app/api/rounds/route.ts
@@ -1,0 +1,55 @@
+import { sql } from "@/lib/db";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS round_results (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL,
+      host TEXT,
+      completed_at TIMESTAMPTZ NOT NULL,
+      participant_times JSONB NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+
+  const rows = await sql`
+    SELECT * FROM round_results ORDER BY completed_at DESC
+  `;
+
+  return NextResponse.json(rows);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { name, host, completedAt, participantTimes } = body as {
+    name: string;
+    host: string | null;
+    completedAt: number;
+    participantTimes: Record<string, number>;
+  };
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS round_results (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL,
+      host TEXT,
+      completed_at TIMESTAMPTZ NOT NULL,
+      participant_times JSONB NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+
+  const [row] = await sql`
+    INSERT INTO round_results (name, host, completed_at, participant_times)
+    VALUES (
+      ${name},
+      ${host},
+      ${new Date(completedAt).toISOString()},
+      ${JSON.stringify(participantTimes)}
+    )
+    RETURNING *
+  `;
+
+  return NextResponse.json(row, { status: 201 });
+}

--- a/app/api/rounds/route.ts
+++ b/app/api/rounds/route.ts
@@ -1,7 +1,8 @@
 import { sql } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
+import z from "zod";
 
-export async function GET() {
+async function ensureTable() {
   await sql`
     CREATE TABLE IF NOT EXISTS round_results (
       id SERIAL PRIMARY KEY,
@@ -12,33 +13,33 @@ export async function GET() {
       created_at TIMESTAMPTZ DEFAULT NOW()
     )
   `;
+}
+
+const RoundResultSchema = z.object({
+  name: z.string(),
+  host: z.string().nullable(),
+  completedAt: z.number(),
+  participantTimes: z.record(z.string(), z.number()),
+});
+
+export async function GET() {
+  await ensureTable();
 
   const rows = await sql`
-    SELECT * FROM round_results ORDER BY completed_at DESC
+    SELECT * FROM round_results ORDER BY completed_at DESC LIMIT 100
   `;
 
   return NextResponse.json(rows);
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { name, host, completedAt, participantTimes } = body as {
-    name: string;
-    host: string | null;
-    completedAt: number;
-    participantTimes: Record<string, number>;
-  };
+  const parsed = RoundResultSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+  }
+  const { name, host, completedAt, participantTimes } = parsed.data;
 
-  await sql`
-    CREATE TABLE IF NOT EXISTS round_results (
-      id SERIAL PRIMARY KEY,
-      name TEXT NOT NULL,
-      host TEXT,
-      completed_at TIMESTAMPTZ NOT NULL,
-      participant_times JSONB NOT NULL,
-      created_at TIMESTAMPTZ DEFAULT NOW()
-    )
-  `;
+  await ensureTable();
 
   const [row] = await sql`
     INSERT INTO round_results (name, host, completed_at, participant_times)

--- a/app/mysteryhooks.ts
+++ b/app/mysteryhooks.ts
@@ -41,3 +41,7 @@ export function useRoundType() {
 export function useParticipantScore(id: string) {
   return useStorage((root) => root.participantScores.get(id));
 }
+
+export function useParticipantTimes() {
+  return useStorage((root) => Object.fromEntries(root.participantTimes));
+}

--- a/components/ui/timer.tsx
+++ b/components/ui/timer.tsx
@@ -7,6 +7,8 @@ import {
   useCompletedTime,
   useHost,
   useIsRunning,
+  useName,
+  useParticipantTimes,
   useRoundLength,
   useStartTime,
 } from "@/app/mysteryhooks";
@@ -34,11 +36,24 @@ export function Timer() {
     setElapsedTime(difference);
   }, 10);
 
+  const name = useName();
+  const participantTimes = useParticipantTimes();
+
   const completeRound = useCompleteRound();
   const startRound = useStartRound();
   const resetRound = useResetRound();
 
   const resetTimer = useResetTimer();
+
+  function handleCompleteRound() {
+    const completedAt = Date.now();
+    completeRound(completedAt);
+    fetch("/api/rounds", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, host, completedAt, participantTimes }),
+    }).catch(console.error);
+  }
 
   function handleResetTimer() {
     if (!confirm("Nollataanko kierros? Järjestäjä pysyy samana.")) return;
@@ -94,7 +109,7 @@ export function Timer() {
       {!startTime && host && (
         <Button onClick={startRound}>AIKA ALKAA NYT!</Button>
       )}
-      {running && <Button onClick={completeRound}>AIKA PÄÄTTYI!</Button>}
+      {running && <Button onClick={handleCompleteRound}>AIKA PÄÄTTYI!</Button>}
       {startTime && !running && (
         <Button onClick={resetRound}>Valitse seuraava järjestäjä</Button>
       )}
@@ -103,8 +118,8 @@ export function Timer() {
 }
 
 function useCompleteRound() {
-  return useMutation(({ storage }) => {
-    storage.set("completedTime", Date.now());
+  return useMutation(({ storage }, completedAt: number) => {
+    storage.set("completedTime", completedAt);
   }, []);
 }
 

--- a/components/ui/timer.tsx
+++ b/components/ui/timer.tsx
@@ -48,11 +48,11 @@ export function Timer() {
   function handleCompleteRound() {
     const completedAt = Date.now();
     completeRound(completedAt);
-    fetch("/api/rounds", {
+    void fetch("/api/rounds", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, host, completedAt, participantTimes }),
-    }).catch(console.error);
+    });
   }
 
   function handleResetTimer() {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,14 @@ const config = [
   },
   ...coreWebVitals,
   ...nextTypescript,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
   prettier,
 ];
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,3 @@
+import { neon } from "@neondatabase/serverless";
+
+export const sql = neon(process.env.DATABASE_URL!);

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ import z from "zod";
 const envValidationResult = z
   .object({
     LIVEBLOCKS_SECRET: z.string(),
+    DATABASE_URL: z.string().url(),
   })
   .safeParse(process.env);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@liveblocks/node": "^3.15.5",
         "@liveblocks/react": "^3.15.5",
         "@liveblocks/react-blocknote": "^3.15.5",
+        "@neondatabase/serverless": "^1.0.2",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/typography": "^0.5.19",
@@ -1518,6 +1519,34 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.2.tgz",
+      "integrity": "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.15.30",
+        "@types/pg": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@neondatabase/serverless/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "16.2.1",
@@ -5971,10 +6000,20 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -11737,6 +11776,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11850,6 +11920,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -13881,7 +13990,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -14354,6 +14462,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y-indexeddb": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@liveblocks/node": "^3.15.5",
     "@liveblocks/react": "^3.15.5",
     "@liveblocks/react-blocknote": "^3.15.5",
+    "@neondatabase/serverless": "^1.0.2",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
## Summary

- Adds `@neondatabase/serverless` and connects to a Neon Postgres database via `DATABASE_URL`
- Creates `lib/db.ts` as the database client and `app/api/rounds/route.ts` with `GET`/`POST` endpoints for round history
- Saves each completed round to a `round_results` table when the host clicks "AIKA PÄÄTTYI!" — exactly one write per round end, from the client who triggered it
- Adds `.env.example` and documents `DATABASE_URL` in `CLAUDE.md`

## Design notes

- The `round_results` table is auto-created on first request (`CREATE TABLE IF NOT EXISTS`), so no migration step is needed for setup
- The save is placed directly in the `handleCompleteRound` event handler in `timer.tsx` rather than in a `useEffect` — per React's "You Might Not Need an Effect" guidance, since this is a direct user action, not external state syncing
- POST body is validated with Zod; `GET` has a `LIMIT 100`
- ESLint configured to respect the `_`-prefix convention for intentionally unused parameters (`argsIgnorePattern: "^_"`)

## Test plan

- Copy `.env.example` to `.env`, fill in `LIVEBLOCKS_SECRET` and `DATABASE_URL`
- Run `npm run dev`, log in, start a round, mark participants done, click "AIKA PÄÄTTYI!"
- `GET /api/rounds` should return the saved round
- Confirm the row appears in the Neon console under `round_results`
- Run `npm run verify` — should pass cleanly