### PR TITLE
Improve loading screen: show nav instantly via SSR, add content skeleton

### DIFF
--- a/app/GameContent.tsx
+++ b/app/GameContent.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ClientSideSuspense } from "@liveblocks/react/suspense";
+import { MysteryRoundPage } from "@/app/MysteryRoundPage";
+
+function LoadingSkeleton() {
+  return (
+    <div className="flex flex-col items-center px-4 py-8 gap-8 sm:py-12">
+      <main className="flex flex-col gap-6 w-full max-w-2xl animate-pulse">
+        <div className="h-12 bg-muted rounded-xl w-2/3" />
+        <div className="h-40 bg-muted rounded-xl" />
+        <div className="h-10 bg-muted rounded-xl w-1/3" />
+        <div className="flex flex-col gap-3">
+          <div className="h-16 bg-muted rounded-xl" />
+          <div className="h-16 bg-muted rounded-xl" />
+          <div className="h-16 bg-muted rounded-xl" />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export function GameContent() {
+  return (
+    <ClientSideSuspense fallback={<LoadingSkeleton />}>
+      <MysteryRoundPage />
+    </ClientSideSuspense>
+  );
+}

--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -4,7 +4,6 @@ import { ReactNode } from "react";
 import {
   LiveblocksProvider,
   RoomProvider,
-  ClientSideSuspense,
 } from "@liveblocks/react/suspense";
 import { LiveList, LiveMap } from "@liveblocks/client";
 import { room } from "@/app/constants";
@@ -37,9 +36,7 @@ export function Room({ children }: { children: ReactNode }) {
           roundInstructions: null,
         }}
       >
-        <ClientSideSuspense fallback={<div>Loading…</div>}>
-          {children}
-        </ClientSideSuspense>
+        {children}
       </RoomProvider>
     </LiveblocksProvider>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,17 +3,39 @@ import { getUsername } from "@/app/login/getUsername";
 import { redirect } from "next/navigation";
 import { MysteryRoundPage } from "@/app/MysteryRoundPage";
 import { TopNav } from "@/app/TopNav";
-import { TournamentName } from "@/app/TournamentName";
+import { ClientSideSuspense } from "@liveblocks/react/suspense";
+import { liveblocks } from "@/app/liveblocks/liveblocks";
+import { room } from "@/app/constants";
+
+function LoadingSkeleton() {
+  return (
+    <div className="flex flex-col items-center px-4 py-8 gap-8 sm:py-12">
+      <main className="flex flex-col gap-6 w-full max-w-2xl animate-pulse">
+        <div className="h-12 bg-muted rounded-xl w-2/3" />
+        <div className="h-40 bg-muted rounded-xl" />
+        <div className="h-10 bg-muted rounded-xl w-1/3" />
+        <div className="flex flex-col gap-3">
+          <div className="h-16 bg-muted rounded-xl" />
+          <div className="h-16 bg-muted rounded-xl" />
+          <div className="h-16 bg-muted rounded-xl" />
+        </div>
+      </main>
+    </div>
+  );
+}
 
 export default async function Home() {
   const username = await getUsername();
   if (!username) {
     return redirect("/login");
   }
+  const storage = await liveblocks.getStorageDocument(room, "json");
   return (
     <Room>
-      <TopNav title={<TournamentName />} />
-      <MysteryRoundPage />
+      <TopNav title={storage.name} />
+      <ClientSideSuspense fallback={<LoadingSkeleton />}>
+        <MysteryRoundPage />
+      </ClientSideSuspense>
     </Room>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,10 @@
 import { Room } from "@/app/Room";
 import { getUsername } from "@/app/login/getUsername";
 import { redirect } from "next/navigation";
-import { MysteryRoundPage } from "@/app/MysteryRoundPage";
 import { TopNav } from "@/app/TopNav";
-import { ClientSideSuspense } from "@liveblocks/react/suspense";
+import { GameContent } from "@/app/GameContent";
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 import { room } from "@/app/constants";
-
-function LoadingSkeleton() {
-  return (
-    <div className="flex flex-col items-center px-4 py-8 gap-8 sm:py-12">
-      <main className="flex flex-col gap-6 w-full max-w-2xl animate-pulse">
-        <div className="h-12 bg-muted rounded-xl w-2/3" />
-        <div className="h-40 bg-muted rounded-xl" />
-        <div className="h-10 bg-muted rounded-xl w-1/3" />
-        <div className="flex flex-col gap-3">
-          <div className="h-16 bg-muted rounded-xl" />
-          <div className="h-16 bg-muted rounded-xl" />
-          <div className="h-16 bg-muted rounded-xl" />
-        </div>
-      </main>
-    </div>
-  );
-}
 
 export default async function Home() {
   const username = await getUsername();
@@ -35,9 +17,7 @@ export default async function Home() {
   return (
     <Room>
       <TopNav title={storage?.name} />
-      <ClientSideSuspense fallback={<LoadingSkeleton />}>
-        <MysteryRoundPage />
-      </ClientSideSuspense>
+      <GameContent />
     </Room>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,10 +29,12 @@ export default async function Home() {
   if (!username) {
     return redirect("/login");
   }
-  const storage = await liveblocks.getStorageDocument(room, "json");
+  const storage = await liveblocks
+    .getStorageDocument(room, "json")
+    .catch(() => null);
   return (
     <Room>
-      <TopNav title={storage.name} />
+      <TopNav title={storage?.name} />
       <ClientSideSuspense fallback={<LoadingSkeleton />}>
         <MysteryRoundPage />
       </ClientSideSuspense>


### PR DESCRIPTION
- Fetch tournament name server-side in page.tsx using liveblocks.getStorageDocument()
  so TopNav renders immediately without waiting for Liveblocks to sync
- Move ClientSideSuspense from Room.tsx into page.tsx, wrapping only MysteryRoundPage
- Replace bare "Loading…" text with a pulsing skeleton layout matching the content area

https://claude.ai/code/session_01PpiyrhUh9j2eBeNFFx8zJL