### PR TITLE
Use ToggleGroup for step 2 round type selection

### DIFF
--- a/app/SetupWizard.tsx
+++ b/app/SetupWizard.tsx
@@ -8,6 +8,7 @@ import "@blocknote/core/fonts/inter.css";
 import "@blocknote/shadcn/style.css";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Check,
   Clock,
@@ -294,6 +295,9 @@ function Step2RoundType() {
   const [minutesValue, setMinutesValue] = React.useState(
     String(Math.round(roundLength / 60000)),
   );
+  const [selectedType, setSelectedType] = React.useState<"time" | "score" | "">(
+    "",
+  );
 
   const setRoundType = useMutation(({ storage }, type: "time" | "score") => {
     storage.set("roundType", type);
@@ -314,6 +318,15 @@ function Step2RoundType() {
     } else {
       setMinutesValue(String(Math.round(roundLength / 60000)));
     }
+  }
+
+  function handleContinue() {
+    if (!selectedType) return;
+    const num = Number(minutesValue);
+    if (Number.isFinite(num) && num > 0) {
+      setRoundLengthMutation(num);
+    }
+    setRoundType(selectedType);
   }
 
   return (
@@ -349,47 +362,46 @@ function Step2RoundType() {
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <button
-          onClick={() => setRoundType("time")}
-          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
-        >
-          <Card className="h-full cursor-pointer transition-colors border-2 hover:border-primary hover:bg-primary/5">
-            <CardContent className="flex flex-col items-center gap-2 py-6 px-4">
-              <Clock className="w-8 h-8 text-primary" />
-              <span className="text-base font-semibold">Aika</span>
-              <span className="text-xs text-muted-foreground text-center">
-                Pelaajat kilpailevat nopeimmasta ratkaisuajasta
-              </span>
-            </CardContent>
-          </Card>
-        </button>
-
-        <button
-          onClick={() => setRoundType("score")}
-          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
-        >
-          <Card className="h-full cursor-pointer transition-colors border-2 hover:border-primary hover:bg-primary/5">
-            <CardContent className="flex flex-col items-center gap-2 py-6 px-4">
-              <Trophy className="w-8 h-8 text-primary" />
-              <span className="text-base font-semibold">Pisteet</span>
-              <span className="text-xs text-muted-foreground text-center">
-                Pelaajille syötetään pisteet kierroksen jälkeen
-              </span>
-            </CardContent>
-          </Card>
-        </button>
-      </div>
-
-      <Button
-        variant="ghost"
-        size="sm"
-        className="self-start"
-        onClick={unsetHost}
+      <ToggleGroup
+        type="single"
+        value={selectedType}
+        onValueChange={(v) => {
+          if (v) setSelectedType(v as "time" | "score");
+        }}
+        className="grid grid-cols-2 gap-3"
       >
-        <ChevronLeft className="w-4 h-4 mr-1" />
-        Takaisin
-      </Button>
+        <ToggleGroupItem
+          value="time"
+          className="h-auto flex-col gap-2 py-6 px-4 border-2 rounded-xl data-[state=on]:border-primary data-[state=on]:bg-primary/10"
+        >
+          <Clock className="w-8 h-8 text-primary" />
+          <span className="text-base font-semibold">Aika</span>
+          <span className="text-xs text-muted-foreground text-center whitespace-normal">
+            Pelaajat kilpailevat nopeimmasta ratkaisuajasta
+          </span>
+        </ToggleGroupItem>
+
+        <ToggleGroupItem
+          value="score"
+          className="h-auto flex-col gap-2 py-6 px-4 border-2 rounded-xl data-[state=on]:border-primary data-[state=on]:bg-primary/10"
+        >
+          <Trophy className="w-8 h-8 text-primary" />
+          <span className="text-base font-semibold">Pisteet</span>
+          <span className="text-xs text-muted-foreground text-center whitespace-normal">
+            Pelaajille syötetään pisteet kierroksen jälkeen
+          </span>
+        </ToggleGroupItem>
+      </ToggleGroup>
+
+      <div className="flex items-center gap-2">
+        <Button onClick={handleContinue} disabled={!selectedType}>
+          Jatka
+        </Button>
+        <Button variant="ghost" size="sm" onClick={unsetHost}>
+          <ChevronLeft className="w-4 h-4 mr-1" />
+          Takaisin
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/SetupWizard.tsx
+++ b/app/SetupWizard.tsx
@@ -108,6 +108,9 @@ export function SetupWizard() {
   const host = useHost();
   const rawRoundType = useStorage((root) => root.roundType);
   const roundInstructions = useRoundInstructions();
+  const [pendingRoundType, setPendingRoundType] = React.useState<
+    "time" | "score" | ""
+  >("");
 
   const currentStep = !host
     ? 1
@@ -121,7 +124,12 @@ export function SetupWizard() {
     <div className="flex flex-col gap-6 w-full">
       <StepIndicator current={currentStep} />
       {currentStep === 1 && <Step1SelectHost />}
-      {currentStep === 2 && <Step2RoundType />}
+      {currentStep === 2 && (
+        <Step2RoundType
+          selectedType={pendingRoundType}
+          onSelectedTypeChange={setPendingRoundType}
+        />
+      )}
       {currentStep === 3 && <Step3Instructions />}
       {currentStep === 4 && <Step4Start />}
     </div>
@@ -290,13 +298,16 @@ function Step1SelectHost() {
 // Step 2 — Round type
 // ---------------------------------------------------------------------------
 
-function Step2RoundType() {
+function Step2RoundType({
+  selectedType,
+  onSelectedTypeChange,
+}: {
+  selectedType: "time" | "score" | "";
+  onSelectedTypeChange: (type: "time" | "score") => void;
+}) {
   const roundLength = useRoundLength();
   const [minutesValue, setMinutesValue] = React.useState(
     String(Math.round(roundLength / 60000)),
-  );
-  const [selectedType, setSelectedType] = React.useState<"time" | "score" | "">(
-    "",
   );
 
   const setRoundType = useMutation(({ storage }, type: "time" | "score") => {
@@ -366,7 +377,7 @@ function Step2RoundType() {
         type="single"
         value={selectedType}
         onValueChange={(v) => {
-          if (v) setSelectedType(v as "time" | "score");
+          if (v) onSelectedTypeChange(v as "time" | "score");
         }}
         className="grid grid-cols-2 gap-3"
       >

--- a/components/ui/toggle-group.tsx
+++ b/components/ui/toggle-group.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/ui/toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+});
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+));
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+});
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle, toggleVariants };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-toggle": "^1.1.10",
+        "@radix-ui/react-toggle-group": "^1.1.11",
         "@tailwindcss/typography": "^0.5.19",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Replaces the two card-buttons with a shadcn ToggleGroup so the selected
option is visually highlighted. Selection no longer auto-advances; a
"Jatka" button (disabled until a type is chosen) commits the choice.

https://claude.ai/code/session_01Ra8GjEZgBZTk4MGGWCJMir