### PR TITLE
Delete hostRounds entry when removing a participant

### DIFF
--- a/app/SetupWizard.tsx
+++ b/app/SetupWizard.tsx
@@ -232,6 +232,7 @@ function Step1SelectHost() {
     const p = storage.get("participants");
     const idx = p.indexOf(name);
     if (idx !== -1) p.delete(idx);
+    storage.get("hostRounds").delete(name);
   }, []);
 
   const moveParticipant = useMutation(

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -28,6 +28,7 @@ export async function removeParticipant(id: string) {
     const participants = root.get("participants");
     const index = participants.findIndex((p) => p === id);
     participants.delete(index);
+    root.get("hostRounds").delete(id);
     console.log(`Removed participant ${id}`);
   });
   revalidatePath("/admin");


### PR DESCRIPTION
When a player is deleted, their completed round data was left orphaned
in the hostRounds LiveMap. Now removeParticipant also clears the entry.

https://claude.ai/code/session_0134VYGYYXayWUJQA35qYvw7