### PR TITLE
Add point calculation explanation to round end screen

### DIFF
--- a/app/Participants.tsx
+++ b/app/Participants.tsx
@@ -9,7 +9,7 @@ import {
   useRoundType,
   useStartTime,
 } from "@/app/mysteryhooks";
-import { Check, CheckCircle2, Flag, Loader2 } from "lucide-react";
+import { Check, CheckCircle2, Flag, HelpCircle, Loader2 } from "lucide-react";
 import { format } from "date-fns";
 import { useRef, useState } from "react";
 
@@ -356,14 +356,81 @@ function ResultsLeaderboard({
 }: {
   results: Array<{ id: string; name: string; pts: number; isHost?: boolean }>;
 }) {
+  const [showExplanation, setShowExplanation] = useState(false);
+  const roundType = useRoundType();
   const playerResults = results.filter((r) => !r.isHost);
   const hostEntry = results.find((r) => r.isHost);
+  const F = playerResults.filter((r) => r.pts > 0).length;
 
   return (
     <div className="w-full">
-      <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
-        Lopputulos
-      </h2>
+      <div className="flex items-center gap-2 mb-3">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Lopputulos
+        </h2>
+        <button
+          onClick={() => setShowExplanation((v) => !v)}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+          title="Miten pisteet lasketaan?"
+        >
+          <HelpCircle className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {showExplanation && (
+        <div className="mb-4 p-3 rounded-lg bg-muted/40 border border-border">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2">
+            Pisteiden laskenta
+          </p>
+          {F === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              {roundType === "time"
+                ? "Kukaan ei maalissa — kaikki saavat 0 pistettä"
+                : "Kukaan ei pisteytetty — kaikki saavat 0 pistettä"}
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <p className="text-xs text-muted-foreground mb-2">
+                {F}{" "}
+                {roundType === "time"
+                  ? "pelaajaa maalissa"
+                  : "pelaajaa pisteytetty"}{" "}
+                — pisteet sijoituksen mukaan
+              </p>
+              {playerResults.map((r, i) => {
+                const isFinisher = r.pts > 0;
+                return (
+                  <div key={r.id} className="flex items-center gap-2 text-xs">
+                    <span className="w-20 text-muted-foreground shrink-0">
+                      {isFinisher
+                        ? `Sija ${i + 1} / ${F}`
+                        : roundType === "time"
+                          ? "DNF"
+                          : "Ei pisteitä"}
+                    </span>
+                    <span className="flex-1 font-medium">{r.name}</span>
+                    <span className="font-mono text-right shrink-0">
+                      {isFinisher ? `${F} - ${i} = +${r.pts} pts` : "+0 pts"}
+                    </span>
+                  </div>
+                );
+              })}
+              {hostEntry && (
+                <div className="flex items-center gap-2 text-xs pt-2 mt-1 border-t border-border">
+                  <span className="w-20 text-muted-foreground shrink-0">
+                    Järjestäjä
+                  </span>
+                  <span className="flex-1 font-medium">{hostEntry.name}</span>
+                  <span className="font-mono text-right shrink-0">
+                    = +{hostEntry.pts} pts (= 1. sija)
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="flex flex-col gap-1">
         {playerResults.map(({ id, name, pts }, i) => (
           <div key={id} className="flex items-center gap-3 px-1 py-2">

--- a/app/Participants.tsx
+++ b/app/Participants.tsx
@@ -10,6 +10,11 @@ import {
   useStartTime,
 } from "@/app/mysteryhooks";
 import { Check, CheckCircle2, Flag, HelpCircle, Loader2 } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { format } from "date-fns";
 import { useRef, useState } from "react";
 
@@ -356,7 +361,6 @@ function ResultsLeaderboard({
 }: {
   results: Array<{ id: string; name: string; pts: number; isHost?: boolean }>;
 }) {
-  const [showExplanation, setShowExplanation] = useState(false);
   const roundType = useRoundType();
   const playerResults = results.filter((r) => !r.isHost);
   const hostEntry = results.find((r) => r.isHost);
@@ -368,68 +372,68 @@ function ResultsLeaderboard({
         <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
           Lopputulos
         </h2>
-        <button
-          onClick={() => setShowExplanation((v) => !v)}
-          className="text-muted-foreground hover:text-foreground transition-colors"
-          title="Miten pisteet lasketaan?"
-        >
-          <HelpCircle className="w-3.5 h-3.5" />
-        </button>
-      </div>
-
-      {showExplanation && (
-        <div className="mb-4 p-3 rounded-lg bg-muted/40 border border-border">
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2">
-            Pisteiden laskenta
-          </p>
-          {F === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              {roundType === "time"
-                ? "Kukaan ei maalissa — kaikki saavat 0 pistettä"
-                : "Kukaan ei pisteytetty — kaikki saavat 0 pistettä"}
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              title="Miten pisteet lasketaan?"
+            >
+              <HelpCircle className="w-3.5 h-3.5" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80" align="start">
+            <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+              Pisteiden laskenta
             </p>
-          ) : (
-            <div className="flex flex-col gap-1">
-              <p className="text-xs text-muted-foreground mb-2">
-                {F}{" "}
+            {F === 0 ? (
+              <p className="text-xs text-muted-foreground">
                 {roundType === "time"
-                  ? "pelaajaa maalissa"
-                  : "pelaajaa pisteytetty"}{" "}
-                — pisteet sijoituksen mukaan
+                  ? "Kukaan ei maalissa — kaikki saavat 0 pistettä"
+                  : "Kukaan ei pisteytetty — kaikki saavat 0 pistettä"}
               </p>
-              {playerResults.map((r, i) => {
-                const isFinisher = r.pts > 0;
-                return (
-                  <div key={r.id} className="flex items-center gap-2 text-xs">
+            ) : (
+              <div className="flex flex-col gap-1">
+                <p className="text-xs text-muted-foreground mb-2">
+                  {F}{" "}
+                  {roundType === "time"
+                    ? "pelaajaa maalissa"
+                    : "pelaajaa pisteytetty"}{" "}
+                  — pisteet sijoituksen mukaan
+                </p>
+                {playerResults.map((r, i) => {
+                  const isFinisher = r.pts > 0;
+                  return (
+                    <div key={r.id} className="flex items-center gap-2 text-xs">
+                      <span className="w-20 text-muted-foreground shrink-0">
+                        {isFinisher
+                          ? `Sija ${i + 1} / ${F}`
+                          : roundType === "time"
+                            ? "DNF"
+                            : "Ei pisteitä"}
+                      </span>
+                      <span className="flex-1 font-medium">{r.name}</span>
+                      <span className="font-mono text-right shrink-0">
+                        {isFinisher ? `${F} - ${i} = +${r.pts} pts` : "+0 pts"}
+                      </span>
+                    </div>
+                  );
+                })}
+                {hostEntry && (
+                  <div className="flex items-center gap-2 text-xs pt-2 mt-1 border-t border-border">
                     <span className="w-20 text-muted-foreground shrink-0">
-                      {isFinisher
-                        ? `Sija ${i + 1} / ${F}`
-                        : roundType === "time"
-                          ? "DNF"
-                          : "Ei pisteitä"}
+                      Järjestäjä
                     </span>
-                    <span className="flex-1 font-medium">{r.name}</span>
+                    <span className="flex-1 font-medium">{hostEntry.name}</span>
                     <span className="font-mono text-right shrink-0">
-                      {isFinisher ? `${F} - ${i} = +${r.pts} pts` : "+0 pts"}
+                      = +{hostEntry.pts} pts (= 1. sija)
                     </span>
                   </div>
-                );
-              })}
-              {hostEntry && (
-                <div className="flex items-center gap-2 text-xs pt-2 mt-1 border-t border-border">
-                  <span className="w-20 text-muted-foreground shrink-0">
-                    Järjestäjä
-                  </span>
-                  <span className="flex-1 font-medium">{hostEntry.name}</span>
-                  <span className="font-mono text-right shrink-0">
-                    = +{hostEntry.pts} pts (= 1. sija)
-                  </span>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+                )}
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+      </div>
 
       <div className="flex flex-col gap-1">
         {playerResults.map(({ id, name, pts }, i) => (

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,15 +1,15 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Popover = PopoverPrimitive.Root
+const Popover = PopoverPrimitive.Root;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
-const PopoverAnchor = PopoverPrimitive.Anchor
+const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
@@ -22,12 +22,12 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
-        className
+        className,
       )}
       {...props}
     />
   </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/typography": "^0.5.19",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
A ? (HelpCircle) button next to the "Lopputulos" heading toggles an
inline breakdown panel showing each player's placement, the formula
(F - rank = pts), DNF/unscored status, and why the host always earns
the same points as 1st place. Adapts text for time vs. score rounds.

https://claude.ai/code/session_01P5JsWGPeQXWDqDzjHAvmNz