### PR TITLE
Add blocknote group to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
         patterns:
           - "next"
           - "eslint-config-next"
+      blocknote:
+        patterns:
+          - "@blocknote/*"
       liveblocks:
         patterns:
           - "@liveblocks/*"


### PR DESCRIPTION
@blocknote/* packages are released together and must be updated atomically.
Without grouping, separate PRs fail verification due to version mismatches.

https://claude.ai/code/session_01QUDaTJBsqUYbasE8BpEqHx