### PR TITLE
Exclude blocknote and liveblocks from patch-updates Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,6 @@ updates:
       patch-updates:
         update-types:
           - "patch"
+        exclude-patterns:
+          - "@blocknote/*"
+          - "@liveblocks/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
         patterns:
           - "next"
           - "eslint-config-next"
+      blocknote:
+        patterns:
+          - "@blocknote/*"
       liveblocks:
         patterns:
           - "@liveblocks/*"


### PR DESCRIPTION
## Summary

- Adds `exclude-patterns` for `@blocknote/*` and `@liveblocks/*` to the `patch-updates` Dependabot group
- These packages have dedicated groups and must be updated atomically; without explicit exclusions the `patch-updates` group also claims them, causing separate PRs that fail verification

https://claude.ai/code/session_01QUDaTJBsqUYbasE8BpEqHx