### PR TITLE
Fix build: add missing @tiptap/suggestion dep and skip admin prerender

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,6 +4,8 @@ import { TopNav } from "@/app/TopNav";
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 import { room } from "@/app/constants";
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminPageServer() {
   const [participants, storage] = await Promise.all([
     getParticipants(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/typography": "^0.5.19",
+        "@tiptap/suggestion": "^3.22.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6082,6 +6083,20 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.22.4.tgz",
+      "integrity": "sha512-1buvLZemITTeKmPf2wGFWvvhRFKjdQ+JgMqc67xBraOKeDd8wQi1e2XlhCYAtlVMm5f6j+qlLC/MvwuHI2jHeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/typography": "^0.5.19",
+    "@tiptap/suggestion": "^3.22.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
- Install @tiptap/suggestion, a peer dep required by @liveblocks/react-tiptap
  that was missing from package.json, causing a module-not-found build error.
- Add `export const dynamic = "force-dynamic"` to /admin page so Next.js
  does not attempt to prerender it at build time (it fetches live Liveblocks
  data that is unavailable during the build).

https://claude.ai/code/session_019JpciTnrtkkvYFhjnqfHJj