### PR TITLE
Show round info card on the active round page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,13 @@ components/ui/                  # Shadcn/ui components
 - Documentation page: `app/mcp/page.tsx`
 - **When adding, removing, or changing MCP tools, always update `app/mcp/page.tsx`** (the `TOOLS` array and `EXAMPLE_PROMPTS`) to keep the docs in sync.
 
+### Pull Requests
+
+First consider whether the PR has visible changes to the user or is purely technical (maintenance, refactoring, dependency updates, etc.).
+
+- **User-facing PRs**: Title and description should lead with what the user sees or experiences differently. Keep technical details brief at the end. E.g. "Show round info card on the active round page" not "Extract RoundInfoCard component for reuse".
+- **Technical PRs**: It is fine to use a technical title and description that focuses on the implementation change.
+
 ### Deployment
 
 - Deployed to Vercel at https://mysteeri.hevirinki.fi/

--- a/app/MysteryRoundPage.tsx
+++ b/app/MysteryRoundPage.tsx
@@ -4,9 +4,7 @@ import { Participants } from "@/app/Participants";
 import {
   useCompletedTime,
   useDescription,
-  useHost,
   useIsRunning,
-  useRoundInstructions,
   useRoundType,
   useStartTime,
 } from "@/app/mysteryhooks";
@@ -14,6 +12,7 @@ import { WakeLock } from "@/app/WakeLock";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { SetupWizard } from "@/app/SetupWizard";
+import { RoundInfoCard } from "@/app/RoundInfoCard";
 import { Info, CheckCircle2 } from "lucide-react";
 
 export function MysteryRoundPage() {
@@ -21,9 +20,7 @@ export function MysteryRoundPage() {
   const isRunning = useIsRunning();
   const completedTime = useCompletedTime();
   const description = useDescription();
-  const roundInstructions = useRoundInstructions();
   const roundType = useRoundType();
-  const host = useHost();
   const isScoreMode = roundType === "score";
 
   return (
@@ -44,29 +41,7 @@ export function MysteryRoundPage() {
 
         {startTime && (
           <>
-            {/* Host banner */}
-            {host && (
-              <div className="flex items-center justify-between bg-muted/30 border rounded-xl px-5 py-3">
-                <div className="flex flex-col">
-                  <span className="text-xs text-muted-foreground">
-                    Järjestäjä
-                  </span>
-                  <span className="text-lg font-bold">{host}</span>
-                </div>
-              </div>
-            )}
-
-            {/* Instructions callout */}
-            {roundInstructions && (
-              <div className="flex gap-3 bg-muted/30 border rounded-xl p-4">
-                <Info className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-                <div className="prose prose-sm dark:prose-invert">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {roundInstructions}
-                  </ReactMarkdown>
-                </div>
-              </div>
-            )}
+            <RoundInfoCard />
 
             {/* Status message */}
             {isRunning && (

--- a/app/RoundInfoCard.tsx
+++ b/app/RoundInfoCard.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Clock, Trophy } from "lucide-react";
+import {
+  useHost,
+  useRoundInstructions,
+  useRoundLength,
+  useRoundType,
+} from "@/app/mysteryhooks";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function RoundInfoCard() {
+  const host = useHost()!;
+  const roundType = useRoundType();
+  const roundInstructions = useRoundInstructions();
+  const roundLength = useRoundLength();
+  const roundMinutes = Math.round(roundLength / 60000);
+
+  return (
+    <Card className="bg-muted/30">
+      <CardContent className="py-4 px-5 flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span className="text-xs text-muted-foreground">Järjestäjä</span>
+            <span className="text-lg font-bold">{host}</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span className="text-xs text-muted-foreground">Kierrosaika</span>
+            <span className="text-lg font-bold">{roundMinutes} min</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          {roundType === "score" ? (
+            <>
+              <Trophy className="w-4 h-4 text-primary shrink-0" />
+              <span className="font-medium">Pistekierros</span>
+            </>
+          ) : (
+            <>
+              <Clock className="w-4 h-4 text-primary shrink-0" />
+              <span className="font-medium">Aikakierros</span>
+            </>
+          )}
+        </div>
+        {roundInstructions ? (
+          <div className="prose prose-sm dark:prose-invert max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {roundInstructions}
+            </ReactMarkdown>
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground italic">
+            Ei ohjeita kirjoitettu.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/SetupWizard.tsx
+++ b/app/SetupWizard.tsx
@@ -36,9 +36,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useStorage } from "@liveblocks/react/suspense";
 import { useParticipants } from "@/app/Participants";
+import { RoundInfoCard } from "@/app/RoundInfoCard";
 import { LiveMap } from "@liveblocks/client";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import {
   DndContext,
   closestCenter,
@@ -514,12 +513,6 @@ function Step3Instructions() {
 // ---------------------------------------------------------------------------
 
 function Step4Start() {
-  const host = useHost()!;
-  const rawRoundType = useStorage((root) => root.roundType);
-  const roundInstructions = useRoundInstructions();
-  const roundLength = useRoundLength();
-  const roundMinutes = Math.round(roundLength / 60000);
-
   const startRound = useMutation(({ storage }) => {
     storage.update({
       startTime: Date.now(),
@@ -542,44 +535,7 @@ function Step4Start() {
         </p>
       </div>
 
-      <Card className="bg-muted/30">
-        <CardContent className="py-4 px-5 flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col">
-              <span className="text-xs text-muted-foreground">Järjestäjä</span>
-              <span className="text-lg font-bold">{host}</span>
-            </div>
-            <div className="flex flex-col items-end">
-              <span className="text-xs text-muted-foreground">Kierrosaika</span>
-              <span className="text-lg font-bold">{roundMinutes} min</span>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 text-sm">
-            {rawRoundType === "score" ? (
-              <>
-                <Trophy className="w-4 h-4 text-primary shrink-0" />
-                <span className="font-medium">Pistekierros</span>
-              </>
-            ) : (
-              <>
-                <Clock className="w-4 h-4 text-primary shrink-0" />
-                <span className="font-medium">Aikakierros</span>
-              </>
-            )}
-          </div>
-          {roundInstructions ? (
-            <div className="prose prose-sm dark:prose-invert max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {roundInstructions}
-              </ReactMarkdown>
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground italic">
-              Ei ohjeita kirjoitettu.
-            </p>
-          )}
-        </CardContent>
-      </Card>
+      <RoundInfoCard />
 
       <div className="flex items-center gap-2">
         <Button


### PR DESCRIPTION
The active round page now shows the same info card as the wizard's final confirmation step — host, duration, round type, and instructions all in one place. Previously the round page had a minimal host-only banner and a separate instructions callout; now it matches the familiar card layout players already see before the round starts.

## Changes
- `RoundInfoCard` extracted into its own component and used in both the wizard and the round page
- Separate host banner + instructions callout in the round page replaced by the shared card

https://claude.ai/code/session_01HxfBLP1EMmJLAYMRspU2Nh