### PR TITLE
Make tournament assistant globally accessible via floating action button

### DIFF
--- a/app/AssistantChat.tsx
+++ b/app/AssistantChat.tsx
@@ -26,10 +26,14 @@ import {
 } from "@/components/ai-elements/prompt-input";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, isStaticToolUIPart } from "ai";
-import { BotIcon } from "lucide-react";
 import { useMemo } from "react";
+import { cn } from "@/lib/utils";
 
-export function AssistantChat() {
+interface AssistantChatProps {
+  className?: string;
+}
+
+export function AssistantChat({ className }: AssistantChatProps) {
   const transport = useMemo(
     () => new DefaultChatTransport({ api: "/api/assistant" }),
     [],
@@ -37,12 +41,9 @@ export function AssistantChat() {
   const { messages, sendMessage, status, stop } = useChat({ transport });
 
   return (
-    <div className="flex flex-col h-[480px] border border-border rounded-xl overflow-hidden bg-card">
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-border text-sm font-medium text-muted-foreground">
-        <BotIcon className="size-4" />
-        AI Assistant
-      </div>
-
+    <div
+      className={cn("flex flex-col h-full overflow-hidden bg-card", className)}
+    >
       <Conversation className="flex-1 min-h-0">
         <ConversationContent>
           {messages.length === 0 && (

--- a/app/AssistantFAB.tsx
+++ b/app/AssistantFAB.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Button } from "@/components/ui/button";
+import { AssistantChat } from "@/app/AssistantChat";
+import { BotIcon, XIcon } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+export function AssistantFAB() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Trigger asChild>
+        <Button
+          size="icon"
+          className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full shadow-lg"
+          aria-label="Open AI Assistant"
+        >
+          <BotIcon className="size-6" />
+        </Button>
+      </DialogPrimitive.Trigger>
+
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          forceMount
+          className={cn(
+            "fixed inset-y-0 right-0 z-[60] flex w-[420px] max-w-full flex-col",
+            "bg-background border-l border-border shadow-xl",
+            "data-[state=open]:animate-in data-[state=open]:slide-in-from-right",
+            "data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right",
+            "duration-300",
+          )}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <span className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <BotIcon className="size-4" />
+              AI Assistant
+            </span>
+            <DialogPrimitive.Close asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <XIcon className="size-4" />
+              </Button>
+            </DialogPrimitive.Close>
+          </div>
+
+          <AssistantChat className="flex-1 min-h-0" />
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/app/MysteryRoundPage.tsx
+++ b/app/MysteryRoundPage.tsx
@@ -13,13 +13,9 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { SetupWizard } from "@/app/SetupWizard";
 import { RoundInfoCard } from "@/app/RoundInfoCard";
-import { Info, CheckCircle2, BotIcon } from "lucide-react";
-import { AssistantChat } from "@/app/AssistantChat";
-import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import { Info, CheckCircle2 } from "lucide-react";
 
 export function MysteryRoundPage() {
-  const [showAssistant, setShowAssistant] = useState(false);
   const startTime = useStartTime();
   const isRunning = useIsRunning();
   const completedTime = useCompletedTime();
@@ -40,18 +36,6 @@ export function MysteryRoundPage() {
               </div>
             )}
             <SetupWizard />
-
-            <Button
-              variant="outline"
-              size="sm"
-              className="self-start gap-2"
-              onClick={() => setShowAssistant((v) => !v)}
-            >
-              <BotIcon className="size-4" />
-              {showAssistant ? "Hide AI Assistant" : "AI Assistant"}
-            </Button>
-
-            {showAssistant && <AssistantChat />}
           </>
         )}
 

--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -20,7 +20,10 @@ const defaultParticipants = [
 
 export function Room({ children }: { children: ReactNode }) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      badgeLocation="bottom-left"
+    >
       <RoomProvider
         id={room}
         initialStorage={{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { AssistantFAB } from "@/app/AssistantFAB";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -29,6 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <AssistantFAB />
       </body>
     </html>
   );


### PR DESCRIPTION
Replaces the pre-round-only inline assistant toggle with a persistent FAB
(bottom-right corner) that opens a slide-in side panel on every page.
Uses Radix Dialog primitives for a11y (focus trap, Escape-to-close).
Chat state is preserved across open/close via forceMount.

https://claude.ai/code/session_01URcLSDMJdXijnk4JJZim3H