### PR TITLE
Teach assistant the remove_participant workflow via tool description

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -232,7 +232,11 @@ function createMcpServer() {
 
   server.tool(
     "reorder_participants",
-    "Reorder the participant list. All current participants must be included.",
+    "Reorder the participant list. Before calling this you MUST call " +
+      "list_participants and build the new order from those exact usernames — " +
+      "every current participant must appear exactly once, spelled exactly as " +
+      "listed (matching is case-sensitive). Do not add, drop, or rename anyone; " +
+      "this only changes order.",
     {
       order: z
         .array(z.string())
@@ -246,13 +250,15 @@ function createMcpServer() {
         const missing = current.filter((p) => !order.includes(p));
         if (missing.length > 0) {
           throw new Error(
-            `Missing participants in new order: ${missing.join(", ")}`,
+            `Missing participants in new order: ${missing.join(", ")}. ` +
+              `Call list_participants for the exact current usernames.`,
           );
         }
         const extra = order.filter((p) => !current.includes(p));
         if (extra.length > 0) {
           throw new Error(
-            `Unknown participants in new order: ${extra.join(", ")}`,
+            `Unknown participants in new order: ${extra.join(", ")}. ` +
+              `Call list_participants for the exact current usernames.`,
           );
         }
 

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -81,13 +81,20 @@ function createMcpServer() {
 
   server.tool(
     "remove_participant",
-    "Remove a participant from the tournament",
+    "Remove a participant from the tournament. Matching is exact and " +
+      "case-sensitive, so before calling this you MUST call list_participants " +
+      "and use the username exactly as it appears there (same capitalization " +
+      "and spacing). If no participant matches what the user asked for, do not " +
+      "guess — show the user the current list and ask which one they mean.",
     { username: z.string().describe("Username to remove") },
     async ({ username }) => {
       await liveblocks.mutateStorage(room, async ({ root }) => {
         const participants = root.get("participants");
         const index = participants.findIndex((p) => p === username);
-        if (index === -1) throw new Error(`${username} not found`);
+        if (index === -1)
+          throw new Error(
+            `${username} not found. Call list_participants to see the exact usernames.`,
+          );
         participants.delete(index);
       });
       return {

--- a/app/mcp/page.tsx
+++ b/app/mcp/page.tsx
@@ -14,7 +14,9 @@ const TOOLS = [
   },
   {
     name: "remove_participant",
-    description: "Removes a participant by username. Errors if not found.",
+    description:
+      "Removes a participant by username. Matching is exact and case-sensitive — " +
+      "check list_participants for the precise spelling first. Errors if not found.",
   },
   {
     name: "reorder_participants",

--- a/app/mcp/page.tsx
+++ b/app/mcp/page.tsx
@@ -21,7 +21,9 @@ const TOOLS = [
   {
     name: "reorder_participants",
     description:
-      "Reorders the participant list. The full list must be provided in the desired order.",
+      "Reorders the participant list. Call list_participants first and provide " +
+      "the full list in the desired order, using the exact usernames. " +
+      "Order-only — does not add or remove anyone.",
   },
   {
     name: "get_tournament_state",


### PR DESCRIPTION
The remove_participant MCP tool matches usernames exactly and
case-sensitively, so assistants that call it directly with the user's
raw spelling fail when capitalization or spacing differs. Update the
tool description to instruct calling list_participants first and using
the exact stored spelling, and make the not-found error point back to
list_participants for recovery. Keep matching logic unchanged. Sync the
/mcp docs page to match.