### PR TITLE
Fix DialogTitle accessibility warning in AI assistant sidebar

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 .next
 .agents
+.playwright-mcp

--- a/app/AssistantFAB.tsx
+++ b/app/AssistantFAB.tsx
@@ -26,6 +26,7 @@ export function AssistantFAB() {
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <DialogPrimitive.Content
           forceMount
+          aria-describedby={undefined}
           className={cn(
             "fixed inset-y-0 right-0 z-[60] flex w-[420px] max-w-full flex-col",
             "bg-background border-l border-border shadow-xl",
@@ -35,10 +36,10 @@ export function AssistantFAB() {
           )}
         >
           <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-            <span className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <DialogPrimitive.Title className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <BotIcon className="size-4" />
               AI Assistant
-            </span>
+            </DialogPrimitive.Title>
             <DialogPrimitive.Close asChild>
               <Button variant="ghost" size="icon" className="h-8 w-8">
                 <XIcon className="size-4" />


### PR DESCRIPTION
## What changed

- Replaced the `<span>` wrapping "AI Assistant" in the sidebar header with `<DialogPrimitive.Title>` — same visual appearance, no layout change
- Added `aria-describedby={undefined}` to `DialogPrimitive.Content` to suppress the secondary Radix warning about a missing description
- Added `.playwright-mcp` to `.prettierignore` so Playwright snapshot artifacts generated during browser testing don't fail the format check

## Why

Opening the AI assistant sidebar produced two console warnings/errors:

```
`DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.
```

Radix UI requires every `DialogContent` to have an associated `DialogTitle` for screen reader accessibility. The title text was already present visually — it just wasn't marked up with the correct primitive.

## Testing

Verified by running the dev server and opening the sidebar in a Playwright browser session — console showed 0 errors/warnings after the fix.