### PR TITLE
Scope Composio connections to a secret per-user id

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -1,7 +1,7 @@
 import { ToolLoopAgent, createAgentUIStreamResponse } from "ai";
 import { createMCPClient } from "@ai-sdk/mcp";
 import { getVercelOidcToken } from "@vercel/oidc";
-import { getUsername } from "@/app/login/getUsername";
+import { getUserId } from "@/app/userId";
 import { Composio } from "@composio/core";
 import { VercelProvider } from "@composio/vercel";
 
@@ -30,12 +30,16 @@ export async function POST(req: Request) {
 
   const mcpTools = await mcpClient.tools();
 
-  // Load Google Sheets tools for the logged-in user. Composio handles auth
-  // in-chat automatically — if the user hasn't connected yet, the tools return
-  // a connect link that the assistant surfaces in the conversation.
-  const username = await getUsername();
-  const sheetsTools = username
-    ? await (await composio.create(username)).tools()
+  // Load Google Sheets tools scoped to the user's secret id (not the
+  // freely-chosen player name), so a connection belongs to the person who made
+  // it and can't be reached by impersonating a player name. Composio handles
+  // auth in-chat automatically — if the user hasn't connected yet, the tools
+  // return a connect link that the assistant surfaces in the conversation.
+  // The id may be absent (proxy hasn't issued it yet); treat that as "not
+  // connected" rather than relying on the cookie always being present.
+  const userId = await getUserId();
+  const sheetsTools = userId
+    ? await (await composio.create(userId)).tools()
     : {};
 
   const tools = { ...mcpTools, ...sheetsTools };

--- a/app/userId.ts
+++ b/app/userId.ts
@@ -1,0 +1,19 @@
+import { cookies } from "next/headers";
+
+/**
+ * Cookie holding the stable, unguessable per-user id.
+ *
+ * Distinct from the `username` cookie: `username` is the freely-chosen player
+ * the user is showing as (forgeable, fine), while this is the user's secret
+ * identity used to scope per-user external resources. Issued by `proxy.ts`.
+ */
+export const USER_ID_COOKIE = "uid";
+
+/**
+ * Reads the current user's id. May be undefined if the cookie has not been
+ * issued yet — callers must handle that case rather than assuming it exists.
+ */
+export async function getUserId(): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  return cookieStore.get(USER_ID_COOKIE)?.value;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -24,7 +24,7 @@ export function proxy(request: NextRequest) {
   const response = NextResponse.next();
   response.cookies.set(USER_ID_COOKIE, crypto.randomUUID(), {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: request.nextUrl.protocol === "https:",
     sameSite: "lax",
     maxAge: 60 * 60 * 24 * 365, // 1 year
     path: "/",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,42 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { USER_ID_COOKIE } from "@/app/userId";
+
+/**
+ * Issues a stable, unguessable per-user id to every visitor.
+ *
+ * The id lives in an httpOnly cookie and acts as the user's secret identity:
+ * it cannot be read by client JS or forged the way the freely-chosen player
+ * `username` cookie can. Server code keys per-user external resources (the
+ * Composio / Google connection, and anything we add later) on this id rather
+ * than the player name, so impersonating a player name does not grant access
+ * to another person's connected accounts.
+ *
+ * Issuance only — never treat the presence of this cookie as authorization.
+ * Each consumer (e.g. the assistant route) must read it server-side at the
+ * point of use and tolerate it being absent.
+ */
+export function proxy(request: NextRequest) {
+  if (request.cookies.has(USER_ID_COOKIE)) {
+    return NextResponse.next();
+  }
+
+  const response = NextResponse.next();
+  response.cookies.set(USER_ID_COOKIE, crypto.randomUUID(), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 365, // 1 year
+    path: "/",
+  });
+  return response;
+}
+
+export const config = {
+  // Run on page navigations only; skip API routes, static assets and metadata
+  // files. The id only needs to exist by the time a page loads — the cookie is
+  // then sent on the subsequent requests that actually consume it.
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+  ],
+};


### PR DESCRIPTION
Previously the assistant keyed each user's Google Sheets / Composio
connection on the `username` cookie. That cookie is the freely-chosen
player name (no password), so anyone could impersonate a player by
picking their name and gain access to that player's connected Google
account.

Issue every visitor a stable, unguessable per-user id in an httpOnly
cookie (`uid`) via proxy.ts, and scope the Composio connection on that
id instead. The player name stays the forgeable display identity; the
secret id is what owns external connections. Built as a general-purpose
user id — Composio is just its first consumer.

The id is issued by the proxy but never trusted as authorization: the
assistant route reads it at the point of use and treats its absence as
"not connected".