### PR TITLE
Pin Node engine version to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "zod": "^4.4.3"
   },
   "engines": {
-    "node": ">=24"
+    "node": "24.x"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",


### PR DESCRIPTION
## Summary
- Vercel flagged `\"node\": \">=24\"` in `package.json` as auto-upgrading on future major Node releases
- Pin to `24.x` so the deployed Node version doesn't silently change on a new major release

## Test plan
- [ ] Confirm Vercel deploy no longer shows the engines warning