### PR TITLE
Use stable user id as the Liveblocks identity

### DIFF
--- a/app/api/liveblocks-auth/route.ts
+++ b/app/api/liveblocks-auth/route.ts
@@ -1,11 +1,18 @@
 import { getUsername } from "@/app/login/getUsername";
+import { getUserId } from "@/app/userId";
 
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 
 export async function POST() {
+  // Identify the Liveblocks user by the stable, server-issued `sub` rather than
+  // the freely-chosen username: before login every visitor would otherwise
+  // share the single identity "anonymous". The proxy issues `sub` on every page
+  // load, so it's practically always present; fall back to a fresh id so a
+  // visitor without one still gets a distinct (if ephemeral) identity.
+  const userId = (await getUserId()) ?? crypto.randomUUID();
   const username = (await getUsername()) ?? "anonymous";
 
-  const session = liveblocks.prepareSession(username, {
+  const session = liveblocks.prepareSession(userId, {
     userInfo: {
       name: username,
     },

--- a/app/api/liveblocks-auth/route.ts
+++ b/app/api/liveblocks-auth/route.ts
@@ -4,9 +4,10 @@ import { getUserId } from "@/app/userId";
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 
 export async function POST() {
-  // getUserId() is unset only if the proxy hasn't run yet; fall back to a
-  // fresh id rather than denying access.
-  const userId = (await getUserId()) ?? crypto.randomUUID();
+  const userId = await getUserId();
+  if (!userId) {
+    return new Response("Unauthorized", { status: 401 });
+  }
   const username = (await getUsername()) ?? "anonymous";
 
   const session = liveblocks.prepareSession(userId, {

--- a/app/api/liveblocks-auth/route.ts
+++ b/app/api/liveblocks-auth/route.ts
@@ -4,11 +4,8 @@ import { getUserId } from "@/app/userId";
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 
 export async function POST() {
-  // Identify the Liveblocks user by the stable, server-issued `sub` rather than
-  // the freely-chosen username: before login every visitor would otherwise
-  // share the single identity "anonymous". The proxy issues `sub` on every page
-  // load, so it's practically always present; fall back to a fresh id so a
-  // visitor without one still gets a distinct (if ephemeral) identity.
+  // getUserId() is unset only if the proxy hasn't run yet; fall back to a
+  // fresh id rather than denying access.
   const userId = (await getUserId()) ?? crypto.randomUUID();
   const username = (await getUsername()) ?? "anonymous";
 

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -38,7 +38,9 @@ declare global {
       hostRounds: LiveMap<string, HostRound>;
     };
 
-    // Custom user info set when authenticating with a secret key
+    // Custom user info set when authenticating with a secret key.
+    // `id` is the stable, server-issued per-user id (the session `sub`);
+    // `info.name` is the freely-chosen display username.
     UserMeta: {
       id: string;
       info: {


### PR DESCRIPTION
Identify Liveblocks users by the stable, server-issued session `sub`
(via getUserId) instead of the freely-chosen username. Before login every
visitor previously authenticated as the single shared identity "anonymous",
collapsing presence and per-user counting. The username is now kept only as
the display name in userInfo.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XD1Z2nVcYsmd1pi6BnkScC