### PR TITLE
Stop showing a Loading flash when navigating between pages

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,5 @@
 import { getParticipants } from "@/app/login/getParticipants";
 import { AdminPage } from "@/app/admin/AdminPage";
-import { TopNav } from "@/app/TopNav";
 import { liveblocks } from "@/app/liveblocks/liveblocks";
 import { room } from "@/app/constants";
 
@@ -12,14 +11,11 @@ export default async function AdminPageServer() {
     liveblocks.getStorageDocument(room, "json"),
   ]);
   return (
-    <>
-      <TopNav />
-      <AdminPage
-        participants={participants}
-        name={storage.name}
-        description={storage.description ?? ""}
-        roundLength={storage.roundLength ?? 20 * 60 * 1000}
-      />
-    </>
+    <AdminPage
+      participants={participants}
+      name={storage.name}
+      description={storage.description ?? ""}
+      roundLength={storage.roundLength ?? 20 * 60 * 1000}
+    />
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { AssistantFAB } from "@/app/AssistantFAB";
+import { Room } from "@/app/Room";
+import { TopNav } from "@/app/TopNav";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -29,7 +31,8 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <TopNav />
+        <Room>{children}</Room>
         <AssistantFAB />
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,8 +2,6 @@ import { getUsername } from "@/app/login/getUsername";
 import { redirect } from "next/navigation";
 
 import { LoginClientPage } from "@/app/login/LoginClientPage";
-import { Room } from "@/app/Room";
-import { TopNav } from "@/app/TopNav";
 
 export default async function Login() {
   const username = await getUsername();
@@ -11,12 +9,5 @@ export default async function Login() {
     return redirect("/");
   }
 
-  return (
-    <>
-      <TopNav />
-      <Room>
-        <LoginClientPage />
-      </Room>
-    </>
-  );
+  return <LoginClientPage />;
 }

--- a/app/mcp/page.tsx
+++ b/app/mcp/page.tsx
@@ -1,7 +1,5 @@
 import { headers } from "next/headers";
 
-import { TopNav } from "@/app/TopNav";
-
 const TOOLS = [
   {
     name: "list_participants",
@@ -73,71 +71,66 @@ export default async function McpPage() {
   const MCP_URL = `${proto}://${host}/api/mcp`;
 
   return (
-    <>
-      <TopNav />
-      <div className="max-w-2xl mx-auto px-6 py-10 space-y-10">
-        <div>
-          <h1 className="text-2xl font-bold mb-2">MCP Server</h1>
-          <p className="text-muted-foreground">
-            Connect your AI assistant to manage the tournament directly.
-          </p>
-        </div>
-
-        <section className="space-y-3">
-          <h2 className="font-semibold">Server URL</h2>
-          <pre className="bg-muted rounded-md px-4 py-3 text-sm font-mono overflow-x-auto">
-            {MCP_URL}
-          </pre>
-        </section>
-
-        <section className="space-y-3">
-          <h2 className="font-semibold">How to connect</h2>
-          <ol className="space-y-2">
-            {STEPS.map((step, i) => (
-              <li key={i} className="flex gap-3 text-sm">
-                <span className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full bg-muted text-muted-foreground font-mono text-xs">
-                  {i + 1}
-                </span>
-                <span className="pt-0.5">{step}</span>
-              </li>
-            ))}
-          </ol>
-          <p className="text-xs text-muted-foreground pt-1">
-            Works on claude.ai (Free, Pro, Max, Team, Enterprise) and Claude
-            Desktop.
-          </p>
-        </section>
-
-        <section className="space-y-3">
-          <h2 className="font-semibold">Example prompts</h2>
-          <div className="flex flex-col gap-2">
-            {EXAMPLE_PROMPTS.map((prompt) => (
-              <div
-                key={prompt}
-                className="bg-muted rounded-md px-4 py-2.5 text-sm font-mono"
-              >
-                {prompt}
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <h2 className="font-semibold">Available Tools</h2>
-          <div className="divide-y divide-border rounded-md border border-border">
-            {TOOLS.map((tool) => (
-              <div key={tool.name} className="px-4 py-3">
-                <code className="text-sm font-mono font-medium">
-                  {tool.name}
-                </code>
-                <p className="text-sm text-muted-foreground mt-0.5">
-                  {tool.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
+    <div className="max-w-2xl mx-auto px-6 py-10 space-y-10">
+      <div>
+        <h1 className="text-2xl font-bold mb-2">MCP Server</h1>
+        <p className="text-muted-foreground">
+          Connect your AI assistant to manage the tournament directly.
+        </p>
       </div>
-    </>
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">Server URL</h2>
+        <pre className="bg-muted rounded-md px-4 py-3 text-sm font-mono overflow-x-auto">
+          {MCP_URL}
+        </pre>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">How to connect</h2>
+        <ol className="space-y-2">
+          {STEPS.map((step, i) => (
+            <li key={i} className="flex gap-3 text-sm">
+              <span className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full bg-muted text-muted-foreground font-mono text-xs">
+                {i + 1}
+              </span>
+              <span className="pt-0.5">{step}</span>
+            </li>
+          ))}
+        </ol>
+        <p className="text-xs text-muted-foreground pt-1">
+          Works on claude.ai (Free, Pro, Max, Team, Enterprise) and Claude
+          Desktop.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">Example prompts</h2>
+        <div className="flex flex-col gap-2">
+          {EXAMPLE_PROMPTS.map((prompt) => (
+            <div
+              key={prompt}
+              className="bg-muted rounded-md px-4 py-2.5 text-sm font-mono"
+            >
+              {prompt}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">Available Tools</h2>
+        <div className="divide-y divide-border rounded-md border border-border">
+          {TOOLS.map((tool) => (
+            <div key={tool.name} className="px-4 py-3">
+              <code className="text-sm font-mono font-medium">{tool.name}</code>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                {tool.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,11 @@
-import { Room } from "@/app/Room";
 import { getUsername } from "@/app/login/getUsername";
 import { redirect } from "next/navigation";
 import { MysteryRoundPage } from "@/app/MysteryRoundPage";
-import { TopNav } from "@/app/TopNav";
 
 export default async function Home() {
   const username = await getUsername();
   if (!username) {
     return redirect("/login");
   }
-  return (
-    <>
-      <TopNav />
-      <Room>
-        <MysteryRoundPage />
-      </Room>
-    </>
-  );
+  return <MysteryRoundPage />;
 }


### PR DESCRIPTION
Mount the Liveblocks Room and TopNav once in the root layout instead
of per-page, so navigating between /, /login, /admin, and /mcp no
longer remounts the room and re-shows the "Loading…" fallback.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DQaTjfx5zfHE3eQQBXqSAN