### PR TITLE
Add get_round_state MCP tool

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -182,6 +182,77 @@ function createMcpServer() {
   );
 
   server.tool(
+    "get_round_state",
+    "Get the current round's host, type, length, instructions, status, " +
+      "and per-participant progress (finished/elapsed time for time rounds, " +
+      "or score for score rounds).",
+    {},
+    async () => {
+      const storage = await liveblocks.getStorageDocument(room, "json");
+      const allParticipants = (storage.participants as string[]) ?? [];
+      const host = (storage.host as string | null) ?? null;
+      const roundType =
+        (storage.roundType as "time" | "score" | null) ?? "time";
+      const roundLength = storage.roundLength as number | null;
+      const roundInstructions =
+        (storage.roundInstructions as string | null) ?? null;
+      const startTime = storage.startTime as number | null;
+      const completedTime = storage.completedTime as number | null;
+      const participantTimes = (storage.participantTimes ?? {}) as Record<
+        string,
+        number
+      >;
+      const participantScores = (storage.participantScores ?? {}) as Record<
+        string,
+        number
+      >;
+
+      const status =
+        startTime === null
+          ? "not_started"
+          : completedTime === null
+            ? "in_progress"
+            : "completed";
+
+      const nonHostParticipants = allParticipants.filter((p) => p !== host);
+
+      const participants =
+        roundType === "time"
+          ? nonHostParticipants.map((username) => {
+              const finishTime = participantTimes[username] ?? null;
+              const elapsedSeconds =
+                finishTime !== null && startTime !== null
+                  ? Math.round((finishTime - startTime) / 1000)
+                  : null;
+              return {
+                username,
+                finished: finishTime !== null,
+                elapsedSeconds,
+              };
+            })
+          : nonHostParticipants.map((username) => ({
+              username,
+              score: participantScores[username] ?? null,
+            }));
+
+      const state = {
+        host,
+        roundType,
+        roundLengthMinutes: roundLength ? roundLength / 60000 : 20,
+        roundInstructions,
+        status,
+        startTime,
+        completedTime,
+        participants,
+      };
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(state, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
     "set_tournament_name",
     "Set the tournament name",
     { name: z.string().describe("New tournament name") },

--- a/app/mcp/page.tsx
+++ b/app/mcp/page.tsx
@@ -34,6 +34,11 @@ const TOOLS = [
       "Returns per-participant results for the current or last round, sorted by finish time. Shows elapsed seconds, DNF status, and points earned this round.",
   },
   {
+    name: "get_round_state",
+    description:
+      "Returns the current round's host, type, length, instructions, status, and per-participant progress (finished/elapsed time or score).",
+  },
+  {
     name: "set_tournament_name",
     description: "Sets the tournament name.",
   },
@@ -53,6 +58,7 @@ const EXAMPLE_PROMPTS = [
   "Remove Charlie from the participants",
   "What is the current tournament name and description?",
   "Show me the results from the last round",
+  "What's the status of the current round?",
   "Set the round length to 15 minutes",
 ];
 


### PR DESCRIPTION
## Summary
- Adds a read-only `get_round_state` MCP tool so the AI assistant can answer questions about the current round (host, type, length, instructions, status, and per-participant finish/score progress) without guessing.
- Updates `app/mcp/page.tsx` docs (`TOOLS` and `EXAMPLE_PROMPTS`) to keep the `/mcp` page in sync.

## Test plan
- [x] `npm run verify` passes
- [x] Called `get_round_state` directly against the running dev server's MCP endpoint and confirmed it returns correct host/type/length/instructions/status and per-participant elapsed times for a completed round
- [ ] Optionally exercise `not_started` / `in_progress` / score-round branches