### PR TITLE
Add .claude/launch.json dev server config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "next-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/launch.json` declaring the project's dev server (`npm run dev` on port 3000) so Claude Code can detect and start it via `preview_start`.

## Test plan
- [x] Used `preview_start` to launch the `next-dev` config and confirmed the server started successfully on port 3000