### PR TITLE
Unpin vercel CLI version in env:pull script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit",
     "format:check": "prettier --check .",
     "verify": "npm run type-check && npm run lint && npm run format:check",
-    "env:pull": "npx vercel@54.18.7 env pull --yes"
+    "env:pull": "npx vercel env pull --yes"
   },
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.55",


### PR DESCRIPTION
## Summary
- Changed `env:pull` npm script from `npx vercel@54.18.7 env pull --yes` to `npx vercel env pull --yes`, so it always uses the latest Vercel CLI instead of a pinned version.

## Test plan
- [x] Verified the script change in `package.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZsgcSUgLzzLNw4mdcuZMJ)_