### PR TITLE
Add support for Liveblocks local dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-# Liveblocks secret key for real-time collaboration
+# Liveblocks secret key for real-time collaboration. Optional: if unset,
+# defaults to "sk_localdev", which only works against the local dev server
+# (see NEXT_PUBLIC_LIVEBLOCKS_BASE_URL below). Required for Liveblocks cloud.
 LIVEBLOCKS_SECRET=
 
 # Secret used to sign session cookies (>=32 chars). Generate with:
@@ -12,6 +14,7 @@ NEXT_PUBLIC_LIVEBLOCKS_ROOM=
 
 # Optional: point the Liveblocks client + node SDK at a local dev server
 # (run `npx liveblocks dev`) instead of Liveblocks cloud. Leave unset to use
-# cloud. When set, also set LIVEBLOCKS_SECRET=sk_localdev above.
+# cloud. LIVEBLOCKS_SECRET defaults to sk_localdev automatically, so no need
+# to set it above.
 #   NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153
 NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ SESSION_SECRET=
 # Set a personal room (e.g. hevilan:dev-<name>) to avoid touching the shared
 # production room — it's created and seeded automatically on server startup.
 NEXT_PUBLIC_LIVEBLOCKS_ROOM=
+
+# Optional: point the Liveblocks client + node SDK at a local dev server
+# (run `npx liveblocks dev`) instead of Liveblocks cloud. Leave unset to use
+# cloud. When set, also set LIVEBLOCKS_SECRET=sk_localdev above.
+#   NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153
+NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# liveblocks local dev server
+/.liveblocks/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,17 @@ npm run verify       # Run all validations (type-check + lint + format check)
 - `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL`: Optional. Points the Liveblocks client (`app/Room.tsx`) and node SDK (`app/liveblocks/liveblocks.ts`) — including the automatic room provisioning in `app/liveblocks/initRoom.ts` — at a [local Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server) (`npx liveblocks dev`, defaults to `http://localhost:1153`) instead of Liveblocks cloud. Leave unset for cloud. See README for the full local setup.
 - The application validates environment variables at build time in `next.config.ts` and will exit if missing.
 
+### Verifying Changes Locally
+
+`npm run verify` only checks types/lint/formatting — it does not prove a feature works. To actually exercise a change end-to-end, run the app against the [local Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server) instead of cloud (no real Liveblocks account needed, and it won't touch the shared production room):
+
+1. Start the dev server in one terminal: `npx liveblocks dev` (binds `http://localhost:1153`, requires [Bun](https://bun.sh/)) — or `docker compose up` if on Windows, which works around a Windows-only path bug in the CLI (see `docker-compose.yml` and the README's "Running Liveblocks locally" section for details).
+2. In `.env.local`, set `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153`. Leave `LIVEBLOCKS_SECRET` unset — it defaults to `sk_localdev`, the only secret the local dev server accepts.
+3. Run `npm run dev` in a second terminal. The room is created and seeded automatically on startup (`app/liveblocks/initRoom.ts`) — no manual seed step needed.
+4. Drive the actual feature rather than just reading the code: open `http://localhost:3000/login`, add/select a player, log in, and exercise the relevant flow (start a round, edit the description, call an MCP tool against `/api/mcp`, etc.). A headless browser (e.g. Playwright) works well for this in a non-interactive session.
+
+Gotcha: if `LIVEBLOCKS_SECRET` is already exported in the surrounding shell environment (common in some sandboxes/CI runners), Next.js gives that real env var precedence over `.env.local`, silently overriding the intended `sk_localdev` value — the local dev server will then reject requests with "you can only use sk_localdev as the secret key". If that happens despite `.env.local` looking correct, check `echo $LIVEBLOCKS_SECRET` and override it inline for the command, e.g. `LIVEBLOCKS_SECRET=sk_localdev npm run dev`.
+
 ## Architecture
 
 ### Real-time State Management with Liveblocks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ npm run verify       # Run all validations (type-check + lint + format check)
 
 ### Environment Variables
 
-- `LIVEBLOCKS_SECRET`: Required for real-time collaboration. Set in `.env` file.
+- `LIVEBLOCKS_SECRET`: Set in `.env` file. Optional — defaults to `sk_localdev` when unset, which only works against the [local Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server) (see `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL` below). A real secret is required for Liveblocks cloud.
 - `SESSION_SECRET`: Required. Secret (>=32 chars) used to sign session cookies. Generate with `openssl rand -base64 32`.
 - `COMPOSIO_API_KEY`: Required for the AI assistant (used by `app/api/assistant/route.ts` to connect external Composio tools).
 - `NEXT_PUBLIC_LIVEBLOCKS_ROOM`: Optional. Overrides the room id (defaults to `hevilan:pti-2025-syksy`). Must keep the `hevilan:` prefix so the auth grant in `app/api/liveblocks-auth/route.ts` matches. Set a personal room (e.g. `hevilan:dev-<name>`) to avoid polluting the shared production room — the room is provisioned automatically the next time you start the server.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,6 @@ npm run verify       # Run all validations (type-check + lint + format check)
 3. Run `npm run dev` in a second terminal. The room is created and seeded automatically on startup (`app/liveblocks/initRoom.ts`) — no manual seed step needed.
 4. Drive the actual feature rather than just reading the code: open `http://localhost:3000/login`, add/select a player, log in, and exercise the relevant flow (start a round, edit the description, call an MCP tool against `/api/mcp`, etc.). A headless browser (e.g. Playwright) works well for this in a non-interactive session.
 
-Gotcha: if `LIVEBLOCKS_SECRET` is already exported in the surrounding shell environment (common in some sandboxes/CI runners), Next.js gives that real env var precedence over `.env.local`, silently overriding the intended `sk_localdev` value — the local dev server will then reject requests with "you can only use sk_localdev as the secret key". If that happens despite `.env.local` looking correct, check `echo $LIVEBLOCKS_SECRET` and override it inline for the command, e.g. `LIVEBLOCKS_SECRET=sk_localdev npm run dev`.
-
 ## Architecture
 
 ### Real-time State Management with Liveblocks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ npm run verify       # Run all validations (type-check + lint + format check)
 - `SESSION_SECRET`: Required. Secret (>=32 chars) used to sign session cookies. Generate with `openssl rand -base64 32`.
 - `COMPOSIO_API_KEY`: Required for the AI assistant (used by `app/api/assistant/route.ts` to connect external Composio tools).
 - `NEXT_PUBLIC_LIVEBLOCKS_ROOM`: Optional. Overrides the room id (defaults to `hevilan:pti-2025-syksy`). Must keep the `hevilan:` prefix so the auth grant in `app/api/liveblocks-auth/route.ts` matches. Set a personal room (e.g. `hevilan:dev-<name>`) to avoid polluting the shared production room — the room is provisioned automatically the next time you start the server.
+- `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL`: Optional. Points the Liveblocks client (`app/Room.tsx`) and node SDK (`app/liveblocks/liveblocks.ts`) — including the automatic room provisioning in `app/liveblocks/initRoom.ts` — at a [local Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server) (`npx liveblocks dev`, defaults to `http://localhost:1153`) instead of Liveblocks cloud. Leave unset for cloud. See README for the full local setup.
 - The application validates environment variables at build time in `next.config.ts` and will exit if missing.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -47,33 +47,24 @@ The app should now run at http://localhost:3000
 Instead of using the hosted Liveblocks cloud, you can run
 [Liveblocks' local dev server](https://liveblocks.io/docs/tools/dev-server) so
 you don't need a real Liveblocks account and don't touch the shared production
-room.
+room. It requires [Bun](https://bun.sh/) (`npm install -g bun`).
 
-The easiest way, on any OS, is Docker Compose:
-
-```
-docker compose up
-```
-
-This starts a server at `http://localhost:1153` (config in
-`docker-compose.yml`) and persists room data in a named Docker volume across
-restarts.
-
-Alternatively, if you have [Bun](https://bun.sh/) installed
-(`npm install -g bun`), you can run the CLI directly:
+In one terminal:
 
 ```
 npx liveblocks dev
 ```
 
-This starts the same server at `http://localhost:1153` and persists room data
-to a local `.liveblocks/` directory. **Avoid this on Windows** — native
-Windows hits a bug in the CLI (as of `liveblocks@1.6.2`) where a
-path-traversal safety check hardcodes a forward slash while `path.resolve`
-returns backslash-separated paths on Windows, so the check always fails —
-every room lookup throws `Error: Invalid internal ID`, regardless of room id
-or data state. Use `docker compose up` instead, which sidesteps this since it
-runs Linux internally.
+This starts a server at `http://localhost:1153` and persists room data to a
+local `.liveblocks/` directory.
+
+**On Windows, run `docker compose up` instead** (config in
+`docker-compose.yml`, persists data in a named Docker volume). Native Windows
+hits a bug in the CLI (as of `liveblocks@1.6.2`) where a path-traversal
+safety check hardcodes a forward slash while `path.resolve` returns
+backslash-separated paths on Windows, so the check always fails — every room
+lookup throws `Error: Invalid internal ID`, regardless of room id or data
+state. Docker Compose sidesteps this since it runs Linux internally.
 
 In `.env.local`, set:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The production runs at https://mysteeri.hevirinki.fi/
 
 - Node.js v24
 - Liveblocks API secret. Set it in `.env` using variable `LIVEBLOCKS_SECRET`
+  (optional — if unset, defaults to `sk_localdev` for use with the [local dev
+  server](#running-liveblocks-locally); a real secret is required for
+  Liveblocks cloud)
 - Composio (for the AI assistant's Google Sheets integration). Set in `.env`:
   - `COMPOSIO_API_KEY` — your Composio project API key
 
@@ -59,9 +62,11 @@ local `.liveblocks/` directory.
 In `.env.local`, set:
 
 ```
-LIVEBLOCKS_SECRET=sk_localdev
 NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153
 ```
+
+(`LIVEBLOCKS_SECRET` defaults to `sk_localdev` automatically when unset, so
+you don't need to set it yourself.)
 
 Then run `npm run dev` as usual in a second terminal — the room is created and
 seeded automatically on startup (see `app/liveblocks/initRoom.ts`), no manual

--- a/README.md
+++ b/README.md
@@ -39,6 +39,35 @@ npm run dev
 
 The app should now run at http://localhost:3000
 
+### Running Liveblocks locally
+
+Instead of using the hosted Liveblocks cloud, you can run
+[Liveblocks' local dev server](https://liveblocks.io/docs/tools/dev-server) so
+you don't need a real Liveblocks account and don't touch the shared production
+room. It requires [Bun](https://bun.sh/) (`npm install -g bun`), or run it via
+Docker instead: `docker run -p 1153:1153 ghcr.io/liveblocks/cli dev`.
+
+In one terminal:
+
+```
+npx liveblocks dev
+```
+
+This starts a server at `http://localhost:1153` and persists room data to a
+local `.liveblocks/` directory.
+
+In `.env.local`, set:
+
+```
+LIVEBLOCKS_SECRET=sk_localdev
+NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153
+```
+
+Then run `npm run dev` as usual in a second terminal — the room is created and
+seeded automatically on startup (see `app/liveblocks/initRoom.ts`), no manual
+seed step needed. Note the local dev server doesn't support Comments,
+Notifications, or AI Copilots, but this app doesn't use any of those.
+
 ## Deployment
 
 The app is deployed using Vercel. The deployment is triggered automatically when changes are pushed to the main branch.

--- a/README.md
+++ b/README.md
@@ -47,25 +47,33 @@ The app should now run at http://localhost:3000
 Instead of using the hosted Liveblocks cloud, you can run
 [Liveblocks' local dev server](https://liveblocks.io/docs/tools/dev-server) so
 you don't need a real Liveblocks account and don't touch the shared production
-room. It requires [Bun](https://bun.sh/) (`npm install -g bun`), or run it via
-Docker instead: `docker run -p 1153:1153 ghcr.io/liveblocks/cli dev`.
+room.
 
-**On Windows, use the Docker command above instead of `npx liveblocks dev`.**
-Native Windows hits a bug in the CLI (as of `liveblocks@1.6.2`) where a
-path-traversal safety check hardcodes a forward slash while
-`path.resolve` returns backslash-separated paths on Windows, so the check
-always fails — every room lookup throws `Error: Invalid internal ID`,
-regardless of room id or data state. Docker sidesteps this since it runs
-Linux internally.
+The easiest way, on any OS, is Docker Compose:
 
-In one terminal:
+```
+docker compose up
+```
+
+This starts a server at `http://localhost:1153` (config in
+`docker-compose.yml`) and persists room data in a named Docker volume across
+restarts.
+
+Alternatively, if you have [Bun](https://bun.sh/) installed
+(`npm install -g bun`), you can run the CLI directly:
 
 ```
 npx liveblocks dev
 ```
 
-This starts a server at `http://localhost:1153` and persists room data to a
-local `.liveblocks/` directory.
+This starts the same server at `http://localhost:1153` and persists room data
+to a local `.liveblocks/` directory. **Avoid this on Windows** — native
+Windows hits a bug in the CLI (as of `liveblocks@1.6.2`) where a
+path-traversal safety check hardcodes a forward slash while `path.resolve`
+returns backslash-separated paths on Windows, so the check always fails —
+every room lookup throws `Error: Invalid internal ID`, regardless of room id
+or data state. Use `docker compose up` instead, which sidesteps this since it
+runs Linux internally.
 
 In `.env.local`, set:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ you don't need a real Liveblocks account and don't touch the shared production
 room. It requires [Bun](https://bun.sh/) (`npm install -g bun`), or run it via
 Docker instead: `docker run -p 1153:1153 ghcr.io/liveblocks/cli dev`.
 
+**On Windows, use the Docker command above instead of `npx liveblocks dev`.**
+Native Windows hits a bug in the CLI (as of `liveblocks@1.6.2`) where a
+path-traversal safety check hardcodes a forward slash while
+`path.resolve` returns backslash-separated paths on Windows, so the check
+always fails — every room lookup throws `Error: Invalid internal ID`,
+regardless of room id or data state. Docker sidesteps this since it runs
+Linux internally.
+
 In one terminal:
 
 ```

--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -19,6 +19,7 @@ export function Room({
   return (
     <LiveblocksProvider
       authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL || undefined}
       badgeLocation="bottom-left"
     >
       <RoomProvider id={room} initialStorage={initialStorage()}>

--- a/app/liveblocks/liveblocks.ts
+++ b/app/liveblocks/liveblocks.ts
@@ -1,6 +1,6 @@
 import { Liveblocks } from "@liveblocks/node";
 
 export const liveblocks = new Liveblocks({
-  secret: process.env.LIVEBLOCKS_SECRET!,
+  secret: process.env.LIVEBLOCKS_SECRET || "sk_localdev",
   baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL || undefined,
 });

--- a/app/liveblocks/liveblocks.ts
+++ b/app/liveblocks/liveblocks.ts
@@ -2,4 +2,5 @@ import { Liveblocks } from "@liveblocks/node";
 
 export const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL || undefined,
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  liveblocks:
+    image: ghcr.io/liveblocks/cli
+    command: dev
+    ports:
+      - "1153:1153"
+    volumes:
+      - liveblocks-data:/app/.liveblocks
+
+volumes:
+  liveblocks-data:

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import z from "zod";
 
 const envValidationResult = z
   .object({
-    LIVEBLOCKS_SECRET: z.string(),
+    LIVEBLOCKS_SECRET: z.string().optional(),
     SESSION_SECRET: z.string().min(32),
   })
   .safeParse(process.env);


### PR DESCRIPTION
## Summary

Adds support for running Liveblocks locally during development, so you can test without a real Liveblocks account and without touching the shared production room.

Closes #261

## Changes

- **`app/liveblocks/liveblocks.ts`** / **`app/Room.tsx`**: Added `baseUrl`, read from `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL`, so both the node SDK and the browser client can point at a local dev server instead of Liveblocks cloud. Leave unset for unchanged cloud behavior.
- **`app/liveblocks/liveblocks.ts`** / **`next.config.ts`**: `LIVEBLOCKS_SECRET` now defaults to `sk_localdev` when unset (the only secret the local dev server accepts), and is no longer required by the build-time env validation. Still required for Liveblocks cloud.
- **`docker-compose.yml`** (new): Runs the Liveblocks dev server via `docker compose up`. Recommended specifically for Windows, since native `npx liveblocks dev` hits a CLI bug there (a path-traversal check hardcodes a forward slash while `path.resolve` returns backslash paths on Windows, so it always throws `Invalid internal ID`).
- **`README.md`**: New "Running Liveblocks locally" section documenting both `npx liveblocks dev` and the Windows Docker Compose workaround.
- **`CLAUDE.md`**: Documents `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL`, and adds a "Verifying Changes Locally" section describing how to actually exercise a feature end-to-end against the local dev server instead of relying only on `npm run verify`.
- **`.env.example`** / **`.gitignore`**: Documents the new env var; ignores the dev server's local `.liveblocks/` data directory.

## Verification

Manually tested end-to-end against `npx liveblocks dev`: created a player, logged in, and edited the tournament description via the browser, confirming the change round-trips through real Liveblocks storage. `docker compose up` was validated for config correctness and confirmed working by testing on Windows, where it fixed the CLI bug described above.

https://claude.ai/code/session_01JvEkgLLTcZYA16CN4wRAWy