### PR TITLE
Fix local Liveblocks dev server on Windows (mutateStorage support)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   liveblocks:
-    image: ghcr.io/liveblocks/cli
-    command: dev
+    build:
+      context: .
+      dockerfile: liveblocks-dev.Dockerfile
     ports:
       - "1153:1153"
     volumes:

--- a/liveblocks-dev.Dockerfile
+++ b/liveblocks-dev.Dockerfile
@@ -1,0 +1,14 @@
+# The published ghcr.io/liveblocks/cli image is stuck on liveblocks@1.0.11, which
+# predates mutateStorage() support in the dev server (added in 1.4.0). This builds
+# a Linux image (avoiding the Windows-only path bug in the CLI, see
+# scripts/validate-liveblocks-devserver-bug.mjs) with an up-to-date CLI version instead.
+FROM oven/bun:1
+WORKDIR /app
+RUN bun add liveblocks@1.6.2
+ENV LIVEBLOCKS_DEVSERVER_HOST=0.0.0.0
+ENV LIVEBLOCKS_DEVSERVER_PORT=1153
+EXPOSE 1153
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD bun -e "fetch('http://localhost:1153').then(()=>process.exit(0)).catch(()=>process.exit(1))"
+ENTRYPOINT ["bun", "run", "node_modules/liveblocks/dist/index.js"]
+CMD ["dev"]


### PR DESCRIPTION
## Summary
- The `ghcr.io/liveblocks/cli` Docker image used for local dev is frozen at `liveblocks@1.0.11`, which predates `mutateStorage()` support in the dev server (added in 1.4.0) — every server-side storage mutation (admin actions like add/remove participant, MCP tools) failed locally with `This endpoint isn't implemented in the Liveblocks dev server.`
- Running the CLI natively on Windows instead of via Docker isn't a fix either — it hits a separate Windows-only path bug in the CLI (`Invalid internal ID`).
- `liveblocks-dev.Dockerfile` builds a Linux image (sidestepping the Windows path bug) with an up-to-date CLI version (1.6.2) installed directly via `bun add`, and `docker-compose.yml` now builds from it instead of pulling the outdated published image.

## Test plan
- [x] `docker compose up -d --build` — new image builds and container reports healthy
- [x] Ran the app against the rebuilt dev server (`NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153`) and drove `/admin` in a browser: added a participant, confirmed the server action succeeded (`Added participant ...` logged, no 501), then removed it
- [x] `npm run verify`